### PR TITLE
fix: add missing JWT credentials dependency

### DIFF
--- a/launchers/connector/build.gradle.kts
+++ b/launchers/connector/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(identityHub.core)
     implementation(identityHub.ext.api)
     implementation(identityHub.core.verifier)
+    implementation(identityHub.ext.credentials.jwt)
 }
 
 application {

--- a/launchers/registrationservice/build.gradle.kts
+++ b/launchers/registrationservice/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(edc.config.filesystem)
     implementation(identityHub.ext.api)
     implementation(identityHub.core.verifier)
+    implementation(identityHub.ext.credentials.jwt)
 
     // To use FileSystem vault e.g. -DuseFsVault="true".Only for non-production usages.
     val useFsVault: Boolean = System.getProperty("useFsVault", "false").toBoolean()


### PR DESCRIPTION
## What this PR changes/adds

Adds a dependency on the `identity-hub-credentials-jwt` module to both launchers (`connector` and `registrationservice`).

## Why it does that

Due to the missing dependency registration of verifiable crendentials at the Identity Hub failed. Thus, the catalog browser was always empty.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly?
