### PR TITLE
fix(docs): resolve markdown syntax errors

### DIFF
--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -242,11 +242,11 @@ cd <project-root>/deployment/azure
 ./shutdown_azure_dataspace.sh
 ```
 
-<br>
+<br/>
 
 ---
 
-<br>
+<br/>
 
 ## Debugging MVD locally
 


### PR DESCRIPTION
## What this PR changes/adds

Resolves markdown syntax mistakes that where introduced in #112.

## Why it does that

As described in #110

## Further notes

--
## Linked Issue(s)

Relates #109

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
