### PR TITLE
fix: set EDC dependencies to fixed version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-version=0.0.1-SNAPSHOT
+version=0.0.1-20230301-SNAPSHOT
 edcGroup=org.eclipse.edc
-registrationServiceVersion=0.0.1-SNAPSHOT
-identityHubVersion=0.0.1-SNAPSHOT
-edcGradlePluginsVersion=0.0.1-SNAPSHOT
-annotationProcessorVersion=0.0.1-SNAPSHOT
-metaModelVersion=0.0.1-SNAPSHOT
+registrationServiceVersion=0.0.1-20230301-SNAPSHOT
+identityHubVersion=0.0.1-20230301-SNAPSHOT
+edcGradlePluginsVersion=0.0.1-20230301-SNAPSHOT
+annotationProcessorVersion=0.0.1-20230301-SNAPSHOT
+metaModelVersion=0.0.1-20230301-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,12 +21,12 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("org.eclipse.edc:edc-versions:0.0.1-SNAPSHOT")
+            from("org.eclipse.edc:edc-versions:0.0.1-20230301-SNAPSHOT")
             library("apache.commons.lang3", "org.apache.commons", "commons-lang3").version("3.12.0")
             library("gatling-highcharts", "io.gatling.highcharts", "gatling-charts-highcharts").version("3.7.5")
         }
         create("identityHub") {
-            version("identityHub", "0.0.1-SNAPSHOT")
+            version("identityHub", "0.0.1-20230301-SNAPSHOT")
             library("spi-core", "org.eclipse.edc", "identity-hub-spi").versionRef("identityHub")
             library("core", "org.eclipse.edc", "identity-hub").versionRef("identityHub")
             library("core-client", "org.eclipse.edc", "identity-hub-client").versionRef("identityHub")
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
 
         }
         create("registrationService") {
-            version("registrationService", "0.0.1-SNAPSHOT")
+            version("registrationService", "0.0.1-20230301-SNAPSHOT")
             library("core", "org.eclipse.edc", "registration-service").versionRef("registrationService")
             library(
                 "core-credential-service",
@@ -57,14 +57,14 @@ dependencyResolutionManagement {
         }
 
         create("fcc") {
-            version("catalog", "0.0.1-SNAPSHOT")
+            version("catalog", "0.0.1-20230301-SNAPSHOT")
             library("api", "org.eclipse.edc", "federated-catalog-api").versionRef("catalog")
             library("spi", "org.eclipse.edc", "federated-catalog-spi").versionRef("catalog")
             library("core", "org.eclipse.edc", "federated-catalog-core").versionRef("catalog")
         }
 
         create("edc") {
-            version("edc", "0.0.1-SNAPSHOT")
+            version("edc", "0.0.1-20230301-SNAPSHOT")
             library("util", "org.eclipse.edc", "util").versionRef("edc")
             library("boot", "org.eclipse.edc", "boot").versionRef("edc")
             library("junit", "org.eclipse.edc", "junit").versionRef("edc")
@@ -87,7 +87,7 @@ dependencyResolutionManagement {
 
 
             library("ext-auth-tokenBased", "org.eclipse.edc", "auth-tokenbased").versionRef("edc")
-            library("api-dataManagement", "org.eclipse.edc", "data-management-api").versionRef("edc")
+            library("api-dataManagement", "org.eclipse.edc", "management-api").versionRef("edc")
             library("api-observability", "org.eclipse.edc", "api-observability").versionRef("edc")
             library("micrometer-jetty", "org.eclipse.edc", "jetty-micrometer").versionRef("edc")
             library("micrometer-jersey", "org.eclipse.edc", "jersey-micrometer").versionRef("edc")
@@ -108,9 +108,10 @@ dependencyResolutionManagement {
             library("dpf-selector-spi", "org.eclipse.edc", "data-plane-selector-spi").versionRef("edc")
             library("dpf-selector-core", "org.eclipse.edc", "data-plane-selector-core").versionRef("edc")
             library("dpf-framework", "org.eclipse.edc", "data-plane-framework").versionRef("edc")
-            library("dpf-transfer-client", "org.eclipse.edc", "data-plane-transfer-client").versionRef("edc")
+            library("dpf-transfer-client", "org.eclipse.edc", "data-plane-client").versionRef("edc")
             library("dpf-selector-client", "org.eclipse.edc", "data-plane-selector-client").versionRef("edc")
             library("dpf-storage-azure", "org.eclipse.edc", "data-plane-azure-storage").versionRef("edc")
+            library("transfer-data-plane", "org.eclipse.edc", "transfer-data-plane").versionRef("edc")
 
             bundle(
                 "identity",
@@ -129,7 +130,8 @@ dependencyResolutionManagement {
                     "dpf-selector-spi",
                     "dpf-selector-core",
                     "dpf-framework",
-                    "dpf-storage-azure"
+                    "dpf-storage-azure",
+                    "transfer-data-plane"
                 )
             )
         }


### PR DESCRIPTION
## What this PR changes/adds

Sets the version for all EDC dependencies to `0.0.1-20230301-SNAPSHOT`. Updates names of dependencies that have changed.

## Why it does that

So that the main branch of the MVD successfully builds.

## Further notes

This keeps the issue mentioned in #132 from occurring, but the MVD should still be updated to fix that issue. The problem causing this issue seems to be refactoring in the RegistrationService repository:
- the package name of `ParticipantDto` has changed, which is an easy fix
- `RegistryApi` and `ApiClientFactory` have been refactored (not just renamed) so the `RegistrationServiceNodeDirectoryExtension` int the MVD fails to initialize
