### PR TITLE
fix: CLOUD-CD pipeline

### DIFF
--- a/.github/workflows/cloud-cd.yaml
+++ b/.github/workflows/cloud-cd.yaml
@@ -1,6 +1,7 @@
 name: CLOUD-CD
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -11,31 +11,6 @@ As a fully decentralized dataspace is hard to imagine, the MVD also serves the p
 
 Developer documentation can be found under [docs/developer](docs/developer), where the main concepts and decisions are captured as [decision records](docs/developer/decision-records/).
 
-## Create Dataspace Deployment
-
-To be able to deploy your own dataspace instances, you first need to [fork the MVD repository and set up your environment](docs/developer/continuous-deployment/continuous_deployment.md).
-
-Once your environment is set up, follow these steps to create a new dataspace instance:
-
-- Go to your MVD fork in GitHub.
-- Select the tab called `Actions`.
-- Select the workflow called `Deploy`.
-- Provide your own resources name prefix. The prefix must be 3 to 7 lowercase letters and digits, starting with a letter.
-  This name prefix ensures the resources name's uniqueness and avoids resource name conflicts.
-  Note down the used prefix.
-- Click on `Run workflow` to trigger the deployment.
-
-## Destroy Dataspace Deployment
-
-Follow these steps to delete a dataspace instance and free up the corresponding resources:
-
-- Go to your MVD fork in GitHub.
-- Select the tab called `Actions`
-- Select the workflow called `Destroy`
-- Click on `Run workflow`
-- Provide the resources prefix that you used when you deployed your DataSpace.
-- Click on `Run workflow` to trigger to destroy your MinimumViableDataspace DataSpace.
-
 ## Local Development Setup
 
 The MVD backend and MVD UI (Data Dashboard) can be run locally for testing and development.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Developer documentation can be found under [docs/developer](docs/developer), whe
 
 The MVD backend and MVD UI (Data Dashboard) can be run locally for testing and development.
 
-1. Check out the
-   repository [eclipse-edc/DataDashboard](https://github.com/eclipse-edc/DataDashboard) or
+1. Check out the repository [eclipse-edc/DataDashboard](https://github.com/eclipse-edc/DataDashboard) or
    your corresponding fork.
 2. Set the environment variable `MVD_UI_PATH` to the path of the DataDashboard repository. (See example below.)
 3. Use the instructions in section `Publish/Build Tasks` [system-tests/README.md](system-tests/README.md) to set up a
@@ -29,7 +28,7 @@ The MVD backend and MVD UI (Data Dashboard) can be run locally for testing and d
 
 ```bash
 export MVD_UI_PATH="/path/to/mvd-datadashboard"
-docker-compose --profile ui -f system-tests/docker-compose.yml up --build
+docker compose --profile ui -f system-tests/docker-compose.yml up --build
 ```
 
 > In Windows Docker Compose expects the path to use forward slashes instead of backslashes.

--- a/deployment/azure/create_dataspace_resources.sh
+++ b/deployment/azure/create_dataspace_resources.sh
@@ -22,6 +22,7 @@ env_file="docker/reg.env"
 $sed "s/EDC_VAULT_NAME=\".*\"/EDC_VAULT_NAME=\"$vault_name\"/g" $env_file
 $sed "s/EDC_VAULT_CLIENTSECRET=\".*\"/EDC_VAULT_CLIENTSECRET=\"${APP_CLIENT_SECRET}\"/g" $env_file
 $sed "s/EDC_VAULT_CLIENTID=\".*\"/EDC_VAULT_CLIENTID=\"${APP_CLIENT_ID}\"/g" $env_file
+$sed "s/EDC_VAULT_TENANTID=\".*\"/EDC_VAULT_TENANTID=\"${ARM_TENANT_ID}\"/g" "$env_file"
 $sed "s/EDC_IDENTITY_DID_URL=\".*\"/EDC_IDENTITY_DID_URL=\"did:web:$dataspace_did_host\"/g" $env_file
 
 echo

--- a/deployment/azure/create_participant_resources.sh
+++ b/deployment/azure/create_participant_resources.sh
@@ -25,6 +25,7 @@ for row in $(echo "${data_json}" | jq -r '.[] | @base64'); do
   $sed "s/EDC_VAULT_NAME=\".*\"/EDC_VAULT_NAME=\"$vault_name\"/g" "$env_file"
   $sed "s/EDC_VAULT_CLIENTSECRET=\".*\"/EDC_VAULT_CLIENTSECRET=\"${APP_CLIENT_SECRET}\"/g" "$env_file"
   $sed "s/EDC_VAULT_CLIENTID=\".*\"/EDC_VAULT_CLIENTID=\"${APP_CLIENT_ID}\"/g" "$env_file"
+  $sed "s/EDC_VAULT_TENANTID=\".*\"/EDC_VAULT_TENANTID=\"${ARM_TENANT_ID}\"/g" "$env_file"
   $sed "s/EDC_IDENTITY_DID_URL=\".*\"/EDC_IDENTITY_DID_URL=\"did:web:$did_host\"/g" "$env_file"
   $sed "s/EDC_CONNECTOR_NAME=\".*\"/EDC_CONNECTOR_NAME=\"$conn_name\"/g" "$env_file"
   $sed "s/EDC_API_AUTH_KEY=\".*\"/EDC_API_AUTH_KEY=\"$api_key\"/g" "$env_file"

--- a/deployment/azure/seed_vcs.sh
+++ b/deployment/azure/seed_vcs.sh
@@ -33,8 +33,8 @@ pushCredential() {
 
 checkCredentials() {
   len=$(java -jar identity-hub-cli.jar -s="$ihUrl" vc list | jq -r '. | length')
-  if [ "$len" -lt 2 ]; then
-    echo "Wrong number of VCs, expected > 2, got ${len}"
+  if [ "$len" -lt 1 ]; then
+    echo "Wrong number of VCs, expected > 1, got ${len}"
     exit 2
   fi
 }

--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -243,19 +243,12 @@ Your infrastructure is now set up to run deployments, you can now e.g. run the `
 To change the location where MVD instances will be deployed to, you can optionally change the location in the [variables.tf file](../../../deployment/azure/terraform/modules/participant/sample-data/text-document.txt) for the dataspace authority and in the [variables.tf file](../../../deployment/azure/terraform/modules/participant/sample-data/text-document.txt) for dataspace participants.
 
 ## Pipelines
-### CD
-Deploys the MVD with docker compose and run tests without dependency on Cloud Services.
-Checks if Azure secrets are set up, if confirmed, runs the Azure Dataspace Tests pipeline.
-### Initialize CD
-Creates a resource group with a terraform state storage account and container in Azure.
-### Run Azure Dataspace Tests
-Deploys the MVD with docker compose and run tests.  
-Resources such as Key Vaults and Participants, RegistrationService Blob Storage Containers will be created in Azure.
-### CodeQL
-Performs [CodeQL](https://codeql.github.com/) analysis.
-### Discord Webhook
-Manages [Discord](https://discord.com/developers/docs/resources/webhook) Webhooks for New Discussion, New Issue and New Pull Request.
-### Checks
-Performs style checks on Java and Terraform files.
-### Scan Pull Request
-Performs check on Pull Requests title.
+| Pipeline name                   | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------ |
+| CD | Deploys the MVD with docker compose and run tests without dependency on Cloud Services. <br> Checks if Azure secrets are set up, if confirmed, runs the Azure Dataspace Tests pipeline. |
+| Initialize CD | Creates a resource group with a terraform state storage account and container in Azure. |
+| Run Azure Dataspace Tests |Deploys the MVD with docker compose and run tests. <br> Resources such as Key Vaults and Participants, RegistrationService Blob Storage Containers will be created in Azure. |
+| CodeQL | Performs [CodeQL](https://codeql.github.com/) analysis. |
+| Discord Webhook | Manages [Discord](https://discord.com/developers/docs/resources/webhook) Webhooks for New Discussion, New Issue and New Pull Request. |
+| Checks | Performs style checks on Java and Terraform files. |
+| Scan Pull Request | Performs check on Pull Requests title. |

--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -241,3 +241,21 @@ Your infrastructure is now set up to run deployments, you can now e.g. run the `
 ## Azure Location for MVD Deployments
 
 To change the location where MVD instances will be deployed to, you can optionally change the location in the [variables.tf file](../../../deployment/terraform/dataspace/variables.tf) for the dataspace authority and in the [variables.tf file](../../../deployment/terraform/participant/variables.tf) for dataspace participants.
+
+## Pipelines
+### CD
+Deploys the MVD with docker compose and run tests without dependency on Cloud Services.
+Checks if Azure secrets are set up, if confirmed, runs the Azure Dataspace Tests pipeline.
+### Initialize CD
+Creates a resource group with a terraform state storage account and container in Azure.
+### Run Azure Dataspace Tests
+Deploys the MVD with docker compose and run tests.  
+Resources such as Key Vaults and Participants, RegistrationService Blob Storage Containers will be created in Azure.
+### CodeQL
+Performs [CodeQL](https://codeql.github.com/) analysis.
+### Discord Webhook
+Manages [Discord](https://discord.com/developers/docs/resources/webhook) Webhooks for New Discussion, New Issue and New Pull Request.
+### Checks
+Performs style checks on Java and Terraform files.
+### Scan Pull Request
+Performs check on Pull Requests title.

--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -240,7 +240,7 @@ Your infrastructure is now set up to run deployments, you can now e.g. run the `
 
 ## Azure Location for MVD Deployments
 
-To change the location where MVD instances will be deployed to, you can optionally change the location in the [variables.tf file](../../../deployment/terraform/dataspace/variables.tf) for the dataspace authority and in the [variables.tf file](../../../deployment/terraform/participant/variables.tf) for dataspace participants.
+To change the location where MVD instances will be deployed to, you can optionally change the location in the [variables.tf file](../../../deployment/azure/terraform/modules/participant/sample-data/text-document.txt) for the dataspace authority and in the [variables.tf file](../../../deployment/azure/terraform/modules/participant/sample-data/text-document.txt) for dataspace participants.
 
 ## Pipelines
 ### CD

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -39,7 +39,7 @@ From the `MVD` root folder, execute the following command to build the connector
 Then, to bring up the dataspace, please execute the following command from the `MVD` root folder:
 
 ```bash
-docker-compose -f system-tests/docker-compose.yml up --build
+docker compose -f system-tests/docker-compose.yml up --build
 ```
 
 Once completed, following services will start within their docker containers:
@@ -196,12 +196,12 @@ The script will perform these essential steps:
 ### Running the dataspace + tests
 
 Just like in the [previous chapter](README.md#test-execution-using-embedded-services) we start up our dataspace
-using `docker-compose`. One small difference is that seeding is now done with a separate script instead of inside
+using `docker compose`. One small difference is that seeding is now done with a separate script instead of inside
 another docker container. The reason for this is easier traceability and debuggability.
 
 ```shell
 cd <project-root>/deployment/azure
-docker-compose docker/docker-compose.yaml --build --wait
+docker compose docker/docker-compose.yaml --build --wait
 ./seed_dataspace.sh
 ```
 
@@ -238,7 +238,7 @@ cd <project-root>/deployment/azure
 ## Debugging MVD locally
 
 Follow the instructions in the previous sections to run an MVD with a consumer (`company2`) and provider (`company1`)
-locally using docker-compose.
+locally using `docker compose`.
 
 Once running, you can use a Java debugger to connect to the consumer (`company2`, port 5006) and provider (`company1`,
 port 5005) instances. If you are using IntelliJ you can use the provided "EDC company1", "EDC company2" or "EDC


### PR DESCRIPTION
## What this PR changes/adds

Fixes the Cloud CD pipeline and the associated Run Azure Dataspace Tests pipeline.
Updates the documentation, removed outdated information.

## Why it does that

As reported in the issue #124, the CLOUD CD pipeline stopped working.

## Further notes

The number of pushed credentials was reduced in commit [24c85f2](https://github.com/eclipse-edc/MinimumViableDataspace/commit/24c85f2c7704b86d18b1e0a8e5f5be59d727b514) (PR #119) but `checkCredentials` was not updated accordingly, causing the pipeline to fail.

The `EDC_VAULT_TENANTID` was missing in the `Participant` and `RegistrationService` creation files.

## Linked Issue(s)

Closes #124 
Closes #95 

## Checklist
- [x] added/updated relevant documentation?
- [x] formatted title correctly?

## Additional Contributor
@aykhara
