### PR TITLE
refactor: update pipelines

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,7 +11,7 @@ on:
     paths-ignore:
       - 'docs/**'
 
-# MVD runs using docker-compose based setup with no dependency on cloud services.
+# MVD runs using docker compose based setup with no dependency on cloud services.
 
 jobs:
 
@@ -37,13 +37,13 @@ jobs:
       - name: 'Copy Registration Service and IdentityHub CLI'
         run: ./gradlew getJarsForLocalTest getJarsForAzureTest
 
-      - name: 'Upgrade docker-compose (for --wait option)'
+      - name: 'Upgrade docker compose (for --wait option)'
         run: |
           sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: 'Run MVD docker-compose (incl. MVD UI)'
-        run: docker-compose --profile ui -f system-tests/docker-compose.yml up --build --wait
+      - name: 'Run MVD docker compose (incl. MVD UI)'
+        run: docker compose --profile ui -f system-tests/docker-compose.yml up --build --wait
         timeout-minutes: 10
         env:
           REGISTRATION_SERVICE_LAUNCHER_PATH: ./launchers/registrationservice
@@ -56,8 +56,8 @@ jobs:
           JACOCO: "true"
           TEST_ENVIRONMENT: "local"
 
-      - name: 'docker-compose logs'
-        run: docker-compose -f system-tests/docker-compose.yml logs
+      - name: 'docker compose logs'
+        run: docker compose -f system-tests/docker-compose.yml logs
         if: always()
         env:
           REGISTRATION_SERVICE_LAUNCHER_PATH: ./launchers/registrationservice

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -18,8 +18,6 @@ jobs:
       COMMON_RESOURCE_GROUP_LOCATION: ${{ secrets.COMMON_RESOURCE_GROUP_LOCATION }}
       TERRAFORM_STATE_STORAGE_ACCOUNT: ${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
       TERRAFORM_STATE_CONTAINER: ${{ secrets.TERRAFORM_STATE_CONTAINER }}
-      ACR_NAME: ${{ secrets.ACR_NAME }}
-
     steps:
       - name: 'Az CLI login'
         uses: azure/login@v1
@@ -35,6 +33,3 @@ jobs:
         run: |
           az storage account create --name ${TERRAFORM_STATE_STORAGE_ACCOUNT} --resource-group ${COMMON_RESOURCE_GROUP} -o table
           az storage container create --name ${TERRAFORM_STATE_CONTAINER} --account-name ${TERRAFORM_STATE_STORAGE_ACCOUNT} -o table
-
-      - name: "Create Azure Container Registry"
-        run: az acr create --resource-group "$COMMON_RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic --admin-enabled -o table

--- a/.github/workflows/run_azure_dataspace_tests.yaml
+++ b/.github/workflows/run_azure_dataspace_tests.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: 'Create Dataspace with Terraform'
         run: |
           ./create_azure_dataspace.sh
-          az storage blob upload -c $TERRAFORM_STATE_CONTAINER --account-name $TERRAFORM_STATE_STORAGE_ACCOUNT -f terraform/terraform.tfvars -n terraform.tfvars
+          az storage blob upload --overwrite -c $TERRAFORM_STATE_CONTAINER --account-name $TERRAFORM_STATE_STORAGE_ACCOUNT -f terraform/terraform.tfvars -n terraform.tfvars
 
       - name: 'Upgrade docker-compose (for --wait option)'
         run: |

--- a/docs/developer/continuous-deployment/continuous_deployment.md
+++ b/docs/developer/continuous-deployment/continuous_deployment.md
@@ -219,7 +219,6 @@ Configure the following GitHub secrets which are required by the CD pipeline:
 | `ARM_SUBSCRIPTION_ID`         | The Azure **Subscription ID** to deploy resources to. Navigate to Subscriptions and copy the *Subscription ID* of your subscription. |
 | `COMMON_RESOURCE_GROUP`       | The Azure resource group name to deploy common resources to, such as Azure Container Registry. Choose any valid resource group name, e.g. *rg-mvd-common*. |
 | `COMMON_RESOURCE_GROUP_LOCATION` | The location where common resources should be deployed to, e.g. *eastus*. |
-| `ACR_NAME`                    | The name of the Azure Container Registry to deploy. Use only lowercase letters and numbers. |
 | `TERRAFORM_STATE_STORAGE_ACCOUNT` | The name of the storage account used to store the Terraform state container, e.g. *mvdterraformstates*. |
 | `TERRAFORM_STATE_CONTAINER` | The name of the container used to store the Terraform state blob, e.g. *mvdterraformstates*. |
 

--- a/resources/setup_azure_ad/variables.tf
+++ b/resources/setup_azure_ad/variables.tf
@@ -34,7 +34,7 @@ variable "tf_state_container" {
 variable "common_resourcegroup_location" {
   default = "northeurope"
 }
-# Resource group that'll contain common resources, such as the ACR
+# Resource group that'll contain common resources, such as the Storage account
 variable "common_resourcegroup" {
   default = "mvd-common"
 }


### PR DESCRIPTION
## What this PR changes/adds

- Add the `--overwrite` parameter to command `az storage blob upload` as mentioned in this [issue](https://github.com/Azure/azure-cli/issues/21779).
- Remove references to Azure Container Registry
- Upgrade the docker compose version to V2 in `cd.yaml`

## Why it does that

- The absence of the `--overwrite` parameter in the `az storage blob upload` command prevents a successful execution of the [run_azure_dataspace_tests.yaml](https://github.com/eclipse-edc/MinimumViableDataspace/actions/runs/4742734427/jobs/8421373780) pipeline when the blob storage already exists.

- Since the `Deploy` pipeline has been removed (#128) there is no need to create an Azure Container Registry.

- Upgrading to docker compose V2 in cd.yaml as suggested by @paullatzelsperger in PR #137.

## Linked Issue(s)

Closes #128

## Checklist

- [x] added/updated relevant documentation?
- [x] formatted title correctly?
