### PR TITLE
docs: hint on key management in system-tests

### DIFF
--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -112,7 +112,7 @@ openssl req -new -x509 -key private-key.pem -out cert.pem -days 360
 Generated keys are imported to keystores e.g. `system-tests/resources/vault/company1/company1-keystore.jks`. Each
 keystore has password `test123`.
 
-> [KeyStore Explorer](https://keystore-explorer.org/) can be used to manage keystores from UI.
+> [KeyStore Explorer](https://keystore-explorer.org/) should be used to manage keystores (from UI). Using `openssl` combined with `keytool` to obtain a `JKS` keystore will result in a keystore the EDC cannot read (incompatible inclusion of key parameters).
 
 `MVD` local instances use a file-system based vault and its keys are managed using a java properties file
 e.g.`system-tests/resources/vault/company[1,2,3]/company[1,2,3]-vault.properties`.


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a warning to the `system-tests/README.md` to ease generation of key material.

## Why it does that

It is not specified how to create the keystore based on the generated key material. Using the standard way based on `openssl` export followed by conversion using `keytool` removes a -- redundant -- copy of the EC parameters in the contained keys. This breaks the keystore parsing in the EDC. Using the `KeyStore Explorer`, this does not happen.