### PR TITLE
chore: Bump EDC components version to 0.1.2

### DIFF
--- a/extensions/policies/src/test/java/org/eclipse/edc/mvd/RegionConstraintFunctionTest.java
+++ b/extensions/policies/src/test/java/org/eclipse/edc/mvd/RegionConstraintFunctionTest.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.mvd;
 
 import org.eclipse.edc.identityhub.spi.credentials.model.Credential;
 import org.eclipse.edc.identityhub.spi.credentials.model.CredentialSubject;
-import org.eclipse.edc.policy.engine.PolicyContextImpl;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.PolicyContextImpl;
 import org.eclipse.edc.policy.model.Operator;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.spi.agent.ParticipantAgent;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-version=0.1.0
+version=0.1.2
 group=org.eclipse.edc
-edcGradlePluginsVersion=0.1.1
-annotationProcessorVersion=0.1.1
-metaModelVersion=0.1.1
+edcGradlePluginsVersion=0.1.2
+annotationProcessorVersion=0.1.2
+metaModelVersion=0.1.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.1.1"
-identityHub = "0.1.1"
-federatedCatalog = "0.1.1"
-registrationService = "0.1.1"
+edc = "0.1.2"
+identityHub = "0.1.2"
+federatedCatalog = "0.1.2"
+registrationService = "0.1.2"
 
 assertj = "3.24.2"
 awaitility = "4.2.0"

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -112,7 +112,8 @@ openssl req -new -x509 -key private-key.pem -out cert.pem -days 360
 Generated keys are imported to keystores e.g. `system-tests/resources/vault/company1/company1-keystore.jks`. Each
 keystore has password `test123`.
 
-> [KeyStore Explorer](https://keystore-explorer.org/) can be used to manage keystores from UI.
+> [KeyStore Explorer](https://keystore-explorer.org/) should be used to manage keystores (from UI).
+> Using `openssl` combined with `keytool` to obtain a `JKS` keystore will result in a keystore the EDC cannot read (incompatible inclusion of key parameters).
 
 `MVD` local instances use a file-system based vault and its keys are managed using a java properties file
 e.g.`system-tests/resources/vault/company[1,2,3]/company[1,2,3]-vault.properties`.


### PR DESCRIPTION
Update EDC components version to `0.1.2` (latest at 26JUN2023).
