### PR TITLE
chore: update to latest DPS-api

### DIFF
--- a/deployment/data/MVD.postman_collection.json
+++ b/deployment/data/MVD.postman_collection.json
@@ -269,7 +269,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n    \"id\": \"dpf-instance_{{participant_id}}\",\r\n    \"url\": \"http://{{participant_id}}:8383/api/control\",\r\n    \"allowedSourceTypes\": [\"AzureStorage\"],\r\n    \"allowedDestTypes\": [\"AzureStorage\"]\r\n}",
+              "raw": "{\r\n    \"@context\": {\"edc\": \"https://w3id.org/edc/v0.0.1/ns/\"}, \"id\": \"dpf-instance_{{participant_id}}\",\r\n    \"url\": \"http://{{participant_id}}:8383/api/control\",\r\n    \"allowedSourceTypes\": [\"AzureStorage\"],\r\n    \"allowedDestTypes\": [\"AzureStorage\"]\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -277,7 +277,7 @@
               }
             },
             "url": {
-              "raw": "{{data_management_url}}/instances",
+              "raw": "{{data_management_url}}/v2/dataplanes",
               "host": [
                 "{{data_management_url}}"
               ],


### PR DESCRIPTION
## What this PR changes/adds

Updates the postman collection to comply with the DataPlane Selector API contained in EDC 0.1.4-SNAPSHOT and later.


## Why it does that

functional compliance

## Further notes

- this PR should only be merged _after_ the next version bump of EDC. 
