### PR TITLE
fix: Adapt MVD to current version of Data Dashboard

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Checkout EDC Data Dashboard
       uses: actions/checkout@v3
       with:
-        repository: eclipse-dataspaceconnector/DataDashboard
+        repository: eclipse-edc/DataDashboard
         path: system-tests/DataDashboard
         ref: ab1b6fd0870fa5ec8c170915a2b44fae63d576bd
 

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -3,13 +3,11 @@ description: "Setup Gradle"
 runs:
   using: "composite"
   steps:
-
     - name: Checkout EDC Data Dashboard
       uses: actions/checkout@v3
       with:
         repository: eclipse-edc/DataDashboard
         path: system-tests/DataDashboard
-        ref: ab1b6fd0870fa5ec8c170915a2b44fae63d576bd
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v3

--- a/.github/workflows/run_azure_dataspace_tests.yaml
+++ b/.github/workflows/run_azure_dataspace_tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: 'Upgrade docker-compose (for --wait option)'
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+          sudo curl -L https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: 'Run Dataspace in Docker'
@@ -89,23 +89,3 @@ jobs:
         run: |
           az storage blob delete -c ${{ env.TERRAFORM_STATE_CONTAINER }} -n ${{ env.RESOURCES_PREFIX }} --account-name ${{ env.TERRAFORM_STATE_STORAGE_ACCOUNT }}
           az storage blob delete -c ${{ env.TERRAFORM_STATE_CONTAINER }} -n terraform.tfvars --account-name ${{ env.TERRAFORM_STATE_STORAGE_ACCOUNT }}
-          
-
-#  Destroy-Dataspace:
-#    if: ${{ always() && needs.SetResourcesPrefix.result == 'success' && needs.Check-Cloud-Environments.outputs.has-azure == 'true'}}
-#    runs-on: ubuntu-latest
-#    needs:
-#      - SetResourcesPrefix
-#      - Deploy
-#      - Check-Cloud-Environments
-#    defaults:
-#      run:
-#        working-directory: deployment/azure
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: ./.github/actions/gradle-setup
-#
-#      - name: 'Destroy Dataspace with Terraform'
-#        run: |
-#          ./shutdown_azure_dataspace.sh
-

--- a/.github/workflows/run_azure_dataspace_tests.yaml
+++ b/.github/workflows/run_azure_dataspace_tests.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/gradle-setup
 
-      - name: 'Copy IdentityHub and RegistrationService CLI Jars'
+      - name: 'Copy IdentityHub and RegistrationService CLI JARs'
         run: |
           ./gradlew getJarsForLocalTest getJarsForAzureTest
         working-directory: .
@@ -58,21 +58,16 @@ jobs:
           ./gradlew shadowJar
         working-directory: .
 
-      - name: 'Create Dataspace with Terraform'
+      - name: 'Create dataspace with Terraform'
         run: |
           ./create_azure_dataspace.sh
           az storage blob upload --overwrite -c $TERRAFORM_STATE_CONTAINER --account-name $TERRAFORM_STATE_STORAGE_ACCOUNT -f terraform/terraform.tfvars -n terraform.tfvars
 
-      - name: 'Upgrade docker-compose (for --wait option)'
+      - name: 'Run dataspace in Docker'
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
+          docker compose -f docker/docker-compose.yml up --build --wait
 
-      - name: 'Run Dataspace in Docker'
-        run: |
-          docker-compose -f docker/docker-compose.yml up --build --wait
-
-      - name: 'Seed Credentials and master data'
+      - name: 'Seed credentials and master data'
         run: |
           ./seed_dataspace.sh
 

--- a/deployment/azure/docker/docker-compose.yml
+++ b/deployment/azure/docker/docker-compose.yml
@@ -1,12 +1,11 @@
-version: "3"
-name: "mvd-with-azure"
+version: "3.9"
 services:
 
   # EDC Connector to simulate a dataspace participant acting as a data provider which is located in EU.
   company1:
     container_name: company1
     build:
-      context: ../../launchers/connector
+      context: ../../../launchers/connector
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     env_file:
@@ -25,7 +24,7 @@ services:
   company2:
     container_name: company2
     build:
-      context: ../../launchers/connector
+      context: ../../../launchers/connector
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006"
     env_file:
@@ -44,7 +43,7 @@ services:
   company3:
     container_name: company3
     build:
-      context: ../../launchers/connector
+      context: ../../../launchers/connector
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007"
     env_file:
@@ -59,12 +58,11 @@ services:
     volumes:
       - ../resources/self-description/company3:/resources
 
-
   # Dataspace registration service authority.
   registration-service:
     container_name: registration-service
     build:
-      #e.g. /home/user/RegistrationService/launcher
+      # e.g. /home/user/RegistrationService/launcher
       context: ../../../launchers/registrationservice
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008"
@@ -82,7 +80,7 @@ services:
   company1-datadashboard:
     container_name: company1-datadashboard
     build:
-      context: ${MVD_UI_PATH}
+      context: ../../system-tests/DataDashboard
     volumes:
       - ../resources/appconfig/company1:/usr/share/nginx/html/assets/config
     depends_on:
@@ -97,7 +95,7 @@ services:
   company2-datadashboard:
     container_name: company2-datadashboard
     build:
-      context: ${MVD_UI_PATH}
+      context: ../../system-tests/DataDashboard
     volumes:
       - ../resources/appconfig/company2:/usr/share/nginx/html/assets/config
     depends_on:
@@ -111,7 +109,7 @@ services:
   company3-datadashboard:
     container_name: company3-datadashboard
     build:
-      context: ${MVD_UI_PATH}
+      context: ../../system-tests/DataDashboard
     volumes:
       - ../resources/appconfig/company3:/usr/share/nginx/html/assets/config
     depends_on:

--- a/resources/setup_azure_ad/main.tf
+++ b/resources/setup_azure_ad/main.tf
@@ -3,22 +3,24 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.26.1"
+      version = ">=2.41.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.16.0"
+      version = ">=3.71.0"
     }
     github = {
       source  = "integrations/github"
-      version = ">=4.28.0"
+      version = ">=5.34.0"
     }
   }
 }
+
 provider "azurerm" {
   features {
   }
 }
+
 provider "azuread" {
   tenant_id = var.tenant_id
 }

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.9"
 services:
 
   # EDC Connector to simulate a dataspace participant acting as a data provider which is located in EU.

--- a/system-tests/resources/appconfig/company1/app.config.json
+++ b/system-tests/resources/appconfig/company1/app.config.json
@@ -1,6 +1,7 @@
 {
   "apiKey": "ApiKeyDefaultValue",
-  "dataManagementApiUrl": "http://localhost:9191/api/management",
+  "managementApiUrl": "http://localhost:9191/api/management",
+  "catalogUrl": "http://localhost:9191/api/management",
   "storageAccount": "company1assets",
   "storageExplorerLinkTemplate": "storageexplorer://v=1",
   "theme": "theme-1"

--- a/system-tests/resources/appconfig/company2/app.config.json
+++ b/system-tests/resources/appconfig/company2/app.config.json
@@ -1,6 +1,7 @@
 {
   "apiKey": "ApiKeyDefaultValue",
-  "dataManagementApiUrl": "http://localhost:9192/api/management",
+  "managementApiUrl": "http://localhost:9192/api/management",
+  "catalogUrl": "http://localhost:9192/api/management",
   "storageAccount": "company2assets",
   "storageExplorerLinkTemplate": "storageexplorer://v=1",
   "theme": "theme-2"

--- a/system-tests/resources/appconfig/company3/app.config.json
+++ b/system-tests/resources/appconfig/company3/app.config.json
@@ -1,6 +1,7 @@
 {
   "apiKey": "ApiKeyDefaultValue",
-  "dataManagementApiUrl": "http://localhost:9193/api/management",
+  "managementApiUrl": "http://localhost:9193/api/management",
+  "catalogUrl": "http://localhost:9193/api/management",
   "storageAccount": "company3assets",
   "storageExplorerLinkTemplate": "storageexplorer://v=1",
   "theme": "theme-3"


### PR DESCRIPTION
## What this PR changes/adds

- Configuration and paths were adapted to the dashboard
- Versions of dependencies have been increased 

## Why it does that

Current configurations for the data dashbaoard do not work

## Further notes

Docker Compose and Terraform Proivider visions have been increased
