### PR TITLE
fix: change text-document.txt path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All this can also be done using Azure CLI with the following lines from the root
 ```bash
 conn_str="DefaultEndpointsProtocol=http;AccountName=company1assets;AccountKey=key1;BlobEndpoint=http://127.0.0.1:10000/company1assets;"
 az storage container create --name src-container --connection-string $conn_str
-az storage blob upload -f ./deployment/terraform/participant/sample-data/text-document.txt --container-name src-container --name text-document.txt --connection-string $conn_str
+az storage blob upload -f ./deployment/azure/terraform/modules/participant/sample-data/text-document.txt --container-name src-container --name text-document.txt --connection-string $conn_str
 ```
 
 This should result in a similar output as follows. Via the Microsoft Azure Storage Explorer it would be possible to


### PR DESCRIPTION
## What this PR changes/adds

Changes the path of the text-document.txt in the README.

## Why it does that

Fixing

## Linked Issue(s)

Closes #201 