### PR TITLE
fix: Update AppConfig file directories in README.md #183

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ docker compose --profile ui -f system-tests/docker-compose.yml up --build
 
 > In Windows Docker Compose expects the path to use forward slashes instead of backslashes.
 
-The profile `ui` creates three Data Dashboards each connected to an EDC participant. The respective `app.config.json`
-files can be found in the respective directories:
+The profile `ui` creates three Data Dashboards each connected to an EDC participant. 
+Each of these Data Dashboards uses the respective `app.config.json` file which is stored in the 
+respective directories:
 
-- `resources/appconfig/company1/app.config.json`
-- `resources/appconfig/company2/app.config.json`
-- `resources/appconfig/company3/app.config.json`
+- [`./system-tests/resources/appconfig/company1/app.config.json`](./system-tests/resources/appconfig/company1/app.config.json)
+- [`./system-tests/resources/appconfig/company2/app.config.json`](./system-tests/resources/appconfig/company2/app.config.json)
+- [`./system-tests/resources/appconfig/company3/app.config.json`](./system-tests/resources/appconfig/company3/app.config.json)
 
 That's it to run the local development environment. The following section `Run A Standard Scenario Locally` describes a
 standard scenario which can be optionally used with the local development environment.


### PR DESCRIPTION
## What this PR changes/adds

Updates the `app.config.json` file directories in [README.md](https://github.com/FraunhoferISST/edc-mvd/blob/fix/appconfig-files-not-created-183/README.md#local-development-setup)

## Why it does that

The `app.config.json` files exist in the `./system-tests/resources/appconfig/` directory and its creation is not related to MVD deployment. 
The location of these config files, mentioned in the README was not relative to root directory and thus created ambiguity. These files are stored under the [`system-tests/resource`](https://github.com/eclipse-edc/MinimumViableDataspace/tree/main/system-tests/resources) folder and not in the [`resource`](https://github.com/eclipse-edc/MinimumViableDataspace/tree/main/resources) folder that is in root directory.

The README.md file has been updated with the correct locations of `app.config.json` files.


## Linked Issue(s)

Closes #183