### PR TITLE
feat(api): add version API to connector runtimes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ edc-controlplane-services = { module = "org.eclipse.edc:control-plane-aggregate-
 edc-config-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-auth-tokenbased = { module = "org.eclipse.edc:auth-tokenbased", version.ref = "edc" }
 edc-api-management-config = { module = "org.eclipse.edc:management-api-configuration", version.ref = "edc" }
+edc-api-version = { module = "org.eclipse.edc:version-api", version.ref = "edc" }
 edc-api-management = { module = "org.eclipse.edc:management-api", version.ref = "edc" }
 edc-api-management-asset = { module = "org.eclipse.edc:asset-api", version.ref = "edc" }
 edc-api-management-policy = { module = "org.eclipse.edc:policy-definition-api", version.ref = "edc" }

--- a/launchers/connector/build.gradle.kts
+++ b/launchers/connector/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
         println("This runtime compiles with Hashicorp Vault and PostgreSQL. You will need properly configured Postgres and HCV instances.")
     }
     runtimeOnly(libs.bundles.dpf)
+    runtimeOnly(libs.edc.api.version)
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {


### PR DESCRIPTION
## What this PR changes/adds

adds the `/v1/version` API to the connector runtimes

## Why it does that

to demonstrate the Version API

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
