### PR TITLE
feat: environment file for HTTP Client plugin (IntelliJ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ connector-to-connector communication to fail.
 
 All REST requests made from the script are available in
 the [Postman collection](./deployment/postman/MVD.postman_collection.json).
+With the [HTTP Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) 
+and [Import from Postman Collections](https://plugins.jetbrains.com/plugin/22438-import-from-postman-collections)
+plugins, the Postman collection can be imported and then executed by means of the 
+[environment file](./deployment/postman/http-client.env.json), selecting the "Local" environment.
 
 ## Running the Demo (Kubernetes)
 

--- a/deployment/postman/http-client.env.json
+++ b/deployment/postman/http-client.env.json
@@ -1,0 +1,9 @@
+{
+  "Local": {
+    "CS_URL": "http://localhost:7082",
+    "HOST": "http://localhost:8081",
+    "PARTICIPANT_ID": "super-user",
+    "CATALOG_URL": "http://localhost:8084",
+    "DID": "did:web:super-user"
+  }
+}


### PR DESCRIPTION
## What this PR changes/adds

The change includes the environment file that can be used to launch the postman collection using the HTTP Client plugin for IntelliJ

## Why it does that

HTTP Client plugin can import Postman collections and execute them, provided an environment file with the properties:
https://blog.jetbrains.com/idea/2023/09/import-postman-collections-to-the-http-client/
