### PR TITLE
chore: consistent case for X-Api-Key in postman collection

### DIFF
--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -466,7 +466,7 @@
 						"method": "POST",
 						"header": [
 							{
-								"key": "x-api-key",
+								"key": "X-Api-Key",
 								"value": "password"
 							},
 							{
@@ -500,7 +500,7 @@
 						"method": "POST",
 						"header": [
 							{
-								"key": "x-api-key",
+								"key": "X-Api-Key",
 								"value": "password"
 							}
 						],
@@ -1925,7 +1925,7 @@
 					},
 					{
 						"key": "key",
-						"value": "x-api-key",
+						"value": "X-Api-Key",
 						"type": "string"
 					}
 				]
@@ -1964,7 +1964,7 @@
 			},
 			{
 				"key": "key",
-				"value": "x-api-key",
+				"value": "X-Api-Key",
 				"type": "string"
 			}
 		]


### PR DESCRIPTION
- when importing with HTTP client plugin in IntelliJ, only one key is generated

