### PR TITLE
fix: remove spaces around = in env files

### DIFF
--- a/deployment/assets/env/consumer_connector.env
+++ b/deployment/assets/env/consumer_connector.env
@@ -23,9 +23,9 @@ EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS=10
 EDC_MVD_PARTICIPANTS_LIST_FILE="deployment/assets/participants/participants.local.json"
 
 # dataplane specific config
-EDC_RUNTIME_ID = "consumer-embedded-runtime"
-EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS = "did:web:localhost%3A7083#key-1"
-EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS = "did:web:localhost%3A7083-alias"
-EDC_DPF_SELECTOR_URL = "http://localhost:8083/api/control/v1/dataplanes"
-WEB_HTTP_PUBLIC_PORT = 11001
-WEB_HTTP_PUBLIC_PATH = "/api/public"
+EDC_RUNTIME_ID="consumer-embedded-runtime"
+EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS="did:web:localhost%3A7083#key-1"
+EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS="did:web:localhost%3A7083-alias"
+EDC_DPF_SELECTOR_URL="http://localhost:8083/api/control/v1/dataplanes"
+WEB_HTTP_PUBLIC_PORT=11001
+WEB_HTTP_PUBLIC_PATH="/api/public"

--- a/deployment/assets/env/provider_connector_manufacturing.env
+++ b/deployment/assets/env/provider_connector_manufacturing.env
@@ -23,9 +23,9 @@ EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS=10
 EDC_MVD_PARTICIPANTS_LIST_FILE="deployment/assets/participants/participants.local.json"
 
 # dataplane specific config
-EDC_RUNTIME_ID = "provider-manufacturing-embedded-runtime"
-EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS = "did:web:localhost%3A7093#key-1"
-EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS = "did:web:localhost%3A7093-alias"
-EDC_DPF_SELECTOR_URL = "http://localhost:8293/api/control/v1/dataplanes"
-WEB_HTTP_PUBLIC_PORT = 12002
-WEB_HTTP_PUBLIC_PATH = "/api/public"
+EDC_RUNTIME_ID="provider-manufacturing-embedded-runtime"
+EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS="did:web:localhost%3A7093#key-1"
+EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS="did:web:localhost%3A7093-alias"
+EDC_DPF_SELECTOR_URL="http://localhost:8293/api/control/v1/dataplanes"
+WEB_HTTP_PUBLIC_PORT=12002
+WEB_HTTP_PUBLIC_PATH="/api/public"

--- a/deployment/assets/env/provider_connector_qna.env
+++ b/deployment/assets/env/provider_connector_qna.env
@@ -23,9 +23,9 @@ EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS=10
 EDC_MVD_PARTICIPANTS_LIST_FILE="deployment/assets/participants/participants.local.json"
 
 # dataplane specific config
-EDC_RUNTIME_ID = "provider-qna-embedded-runtime"
-EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS = "did:web:localhost%3A7093#key-1"
-EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS = "did:web:localhost%3A7093-alias"
-EDC_DPF_SELECTOR_URL = "http://localhost:8193/api/control/v1/dataplanes"
-WEB_HTTP_PUBLIC_PORT = 12001
-WEB_HTTP_PUBLIC_PATH = "/api/public"
+EDC_RUNTIME_ID="provider-qna-embedded-runtime"
+EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS="did:web:localhost%3A7093#key-1"
+EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS="did:web:localhost%3A7093-alias"
+EDC_DPF_SELECTOR_URL="http://localhost:8193/api/control/v1/dataplanes"
+WEB_HTTP_PUBLIC_PORT=12001
+WEB_HTTP_PUBLIC_PATH="/api/public"


### PR DESCRIPTION
- to avoid spaces at the end of env variables key name
