### PR TITLE
fix: flaky integration test

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -18,7 +18,7 @@
 #
 
 ---
-name: "Run DCP Demo locally"
+name: "Execute E2E Tests"
 on:
   push:
   pull_request:
@@ -36,7 +36,7 @@ concurrency:
 
 
 jobs:
-  Deploy-with-Terraform:
+  Run-E2E-Tests:
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: "Run E2E Test"
         run: |-
-          ./gradlew -DincludeTags="EndToEndTest" test -DverboseTest=true
+          ./gradlew -DincludeTags="EndToEndTest" test -DverboseTest=true || kubectl logs deployment/provider-qna-controlplane -n mvd
 
       - name: "Destroy the KinD cluster"
         run: >-

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -99,7 +99,12 @@ jobs:
 
       - name: "Run E2E Test"
         run: |-
-          ./gradlew -DincludeTags="EndToEndTest" test -DverboseTest=true || kubectl logs deployment/provider-qna-controlplane -n mvd
+          ./gradlew -DincludeTags="EndToEndTest" test -DverboseTest=true
+
+      - name: "Print log if test failed"
+        if: failure()
+        run: |-
+          kubectl logs deployment/provider-qna-controlplane -n mvd
 
       - name: "Destroy the KinD cluster"
         run: >-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ edc-api-management-asset = { module = "org.eclipse.edc:asset-api", version.ref =
 edc-api-management-edr = { module = "org.eclipse.edc:edr-cache-api", version.ref = "edc" }
 edc-api-management-policy = { module = "org.eclipse.edc:policy-definition-api", version.ref = "edc" }
 edc-api-management-contractdef = { module = "org.eclipse.edc:contract-definition-api", version.ref = "edc" }
+edc-api-management-dataplaneselector = { module = "org.eclipse.edc:data-plane-selector-api", version.ref = "edc" }
 edc-api-observability = { module = "org.eclipse.edc:api-observability", version.ref = "edc" }
 edc-api-control-configuration = { module = "org.eclipse.edc:control-api-configuration", version.ref = "edc" }
 edc-dsp = { module = "org.eclipse.edc:dsp", version.ref = "edc" }
@@ -163,7 +164,7 @@ dpf = ["edc-dpf-selector-core", "edc-spi-dataplane-selector", "edc-dpf-selector-
 
 connector = ["edc-boot", "edc-core-connector", "edc-ext-http", "edc-ext-observability", "edc-ext-jsonld"]
 
-controlplane = ["edc-controlplane-core", "edc-config-filesystem", "edc-auth-tokenbased", "edc-auth-configuration", "edc-api-management", "edc-api-management-config","edc-api-management-edr",
+controlplane = ["edc-controlplane-core", "edc-config-filesystem", "edc-auth-tokenbased", "edc-auth-configuration", "edc-api-management", "edc-api-management-config","edc-api-management-edr","edc-api-management-dataplaneselector",
     "edc-api-observability", "edc-dsp", "edc-spi-jwt", "edc-ext-http", "edc-controlplane-callback-dispatcher-event", "edc-controlplane-callback-dispatcher-http",
     "edc-identity-core-did", "edc-dcp-core", "edc-identity-trust-transform", "edc-api-control-configuration", "edc-lib-transform",
     "edc-identity-vc-ldp", "edc-did-web", "edc-lib-jws2020", "edc-core-edrstore", "edc-edr-storereceiver"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ edc-ext-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 edc-api-dsp-config = { module = "org.eclipse.edc:dsp-http-api-configuration", version.ref = "edc" }
 edc-dcp = { module = "org.eclipse.edc:identity-trust-service", version.ref = "edc" }
 edc-controlplane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
+edc-controlplane-transform = { module = "org.eclipse.edc:control-plane-transform", version.ref = "edc" }
 edc-controlplane-services = { module = "org.eclipse.edc:control-plane-aggregate-services", version.ref = "edc" }
 edc-config-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-auth-tokenbased = { module = "org.eclipse.edc:auth-tokenbased", version.ref = "edc" }
@@ -69,6 +70,7 @@ edc-lib-jws2020 = { module = "org.eclipse.edc:jws2020-lib", version.ref = "edc" 
 edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 edc-lib-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
 edc-lib-keys = { module = "org.eclipse.edc:keys-lib", version.ref = "edc" }
+edc-lib-jsonld = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
 
 # EDC dataplane client modules (used in controlplane)
 edc-dpf-transfer = { module = "org.eclipse.edc:transfer-data-plane", version.ref = "edc" }

--- a/tests/end2end/build.gradle.kts
+++ b/tests/end2end/build.gradle.kts
@@ -23,4 +23,8 @@ dependencies {
     testImplementation(libs.parsson)
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
+    testImplementation(libs.edc.fc.core)
+    testImplementation(libs.edc.lib.transform)
+    testImplementation(libs.edc.lib.jsonld)
+    testImplementation(libs.edc.controlplane.transform)
 }

--- a/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/transfer/TransferEndToEndTest.java
+++ b/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/transfer/TransferEndToEndTest.java
@@ -111,7 +111,6 @@ public class TransferEndToEndTest {
                             .then()
                             .log().ifError()
                             .statusCode(200)
-                            // yes, it's a bit brittle with the hardcoded indexes, but it appears to work.
                             .extract().body().as(JsonArray.class);
 
                     var offerIdsFiltered = jo.stream().map(jv -> {
@@ -127,8 +126,9 @@ public class TransferEndToEndTest {
                                 .map(offers -> offers.keySet().iterator().next())
                                 .findFirst()
                                 .orElse(null);
-                    });
-                    var oid = offerIdsFiltered.findFirst().orElseThrow();
+                    }).toList();
+                    assertThat(offerIdsFiltered).hasSize(1);
+                    var oid = offerIdsFiltered.get(0);
                     assertThat(oid).isNotNull();
                     offerId.set(oid);
                 });

--- a/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/transfer/TransferEndToEndTest.java
+++ b/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/transfer/TransferEndToEndTest.java
@@ -168,7 +168,7 @@ public class TransferEndToEndTest {
         await().atMost(TEST_TIMEOUT_DURATION)
                 .pollDelay(TEST_POLL_DELAY)
                 .untilAsserted(() -> {
-                    var jp= baseRequest()
+                    var jp = baseRequest()
                             .get(PROVIDER_MANAGEMENT_URL + "/api/management/v3/dataplanes")
                             .then()
                             .statusCode(200)


### PR DESCRIPTION
## What this PR changes/adds

use proper deserialization of the `Catalog[]` response, so we can filter for the `asset-1` of the `provider-qna` connector.

## Why it does that

previously it used hard-coded indices in JSONPath expressions, which is brittle due to the non-canonical form of JSON.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
