### PR TITLE
fix: `ih_schema.sql` to comply with eclipse-edc/IdentityHub#451

### DIFF
--- a/deployment/assets/postgres/ih_schema.sql
+++ b/deployment/assets/postgres/ih_schema.sql
@@ -57,7 +57,8 @@ CREATE TABLE IF NOT EXISTS keypair_resource
     rotation_duration     BIGINT,                                     -- duration during which this keypair is in a transitional state (rotated, not yet deactivated)
     serialized_public_key VARCHAR             NOT NULL,               -- serialized public key (PEM, JWK,...)
     private_key_alias     VARCHAR             NOT NULL,               -- alias under which the private key is stored in the HSM/Vault
-    state                 INT                 NOT NULL DEFAULT 100    -- KeyPairState
+    state                 INT                 NOT NULL DEFAULT 100,   -- KeyPairState
+    key_context           VARCHAR                                     --the key context, will end up in the VerificationMethod of the DID Document
 );
 
 CREATE TABLE IF NOT EXISTS participant_context


### PR DESCRIPTION
## What this PR changes/adds

This change adds the missing `key_context` in `keypair_resource` that was introduced in https://github.com/eclipse-edc/IdentityHub/pull/451.

## Why it does that

Without having this column the services start with an error and does not work as expected:
```
Exception in thread "main" org.eclipse.edc.spi.EdcException: org.eclipse.edc.spi.persistence.EdcPersistenceException: ERROR: column "key_context" of relation "keypair_resource" does not exist
  Position: 181
	at org.eclipse.edc.boot.system.runtime.BaseRuntime.onError(BaseRuntime.java:143)
	at org.eclipse.edc.boot.system.runtime.BaseRuntime.boot(BaseRuntime.java:106)
	at org.eclipse.edc.boot.system.runtime.BaseRuntime.main(BaseRuntime.java:77)
Caused by: org.eclipse.edc.spi.persistence.EdcPersistenceException: ERROR: column "key_context" of relation "keypair_resource" does not exist
  Position: 181
	at org.eclipse.edc.sql.SqlQueryExecutor.execute(SqlQueryExecutor.java:59)
	at org.eclipse.edc.identityhub.store.sql.keypair.SqlKeyPairResourceStore.lambda$create$0(SqlKeyPairResourceStore.java:57)

(full stack trace omitted)
```

## Further notes

I'm not sure how such breaking changes should be propagated to downstream consumers like this sample repo. Maybe the versions of the IdentityHub (and other dependencies) should be pinned.
