### PR TITLE
feat: added Contract Agreement ID call to the collection

### DIFF
--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "7921ef6e-cb34-4f23-b401-f00bf74a12ec",
+		"_postman_id": "31e4b7bb-ba63-490c-8a3d-dbc73ccbe1ca",
 		"name": "MVD+IATP",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "27652630"
+		"_exporter_id": "5621979"
 	},
 	"item": [
 		{
@@ -490,6 +490,27 @@
 								"v3",
 								"contractnegotiations",
 								"request"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Agreement ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{HOST}}/api/management/v3/contractnegotiations/e85301ab-8279-48b0-8a6a-6e8592bd18fd",
+							"host": [
+								"{{HOST}}"
+							],
+							"path": [
+								"api",
+								"management",
+								"v3",
+								"contractnegotiations",
+								"e85301ab-8279-48b0-8a6a-6e8592bd18fd"
 							]
 						}
 					},


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a new **GET** call to the Postman collection, called **"Get Agreement ID"**. The new call hits the following endpoint:  
`/api/management/v3/contractnegotiations/{negotiation_id}`.

## Why it does that

The existing **"Get Contract Negotiations"** API call fetches all available negotiations for a consumer, but for **beginners**, it can be cumbersome to get the entire list and search for a specific negotiation by ID. This new API call allows users to directly retrieve a specific negotiation by its **negotiation ID**, making the process simpler and more efficient for users who already have the ID.

## Further notes

No other significant areas of the code were changed. The addition is limited to the Postman collection.



_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
