### PR TITLE
fix: add STS Account provisioner module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,6 +115,8 @@ edc-sql-ih-credstore-sql = { module = "org.eclipse.edc:identity-hub-credentials-
 edc-sql-ih-didstore-sql = { module = "org.eclipse.edc:identity-hub-did-store-sql", version.ref = "edc" }
 edc-sql-ih-keypairstore-sql = { module = "org.eclipse.edc:identity-hub-keypair-store-sql", version.ref = "edc" }
 edc-sql-ih-pcstore-sql = { module = "org.eclipse.edc:identity-hub-participantcontext-store-sql", version.ref = "edc" }
+edc-sql-ih-stsstore-sql = { module = "org.eclipse.edc:sts-client-store-sql", version.ref = "edc" }
+
 
 # identityhub dependencies
 edc-ih-core = { module = "org.eclipse.edc:identity-hub-core", version.ref = "edc" }
@@ -146,6 +148,8 @@ edc-sts-core = { module = "org.eclipse.edc:identity-trust-sts-core", version.ref
 edc-sts = { module = "org.eclipse.edc:identity-trust-sts-embedded", version.ref = "edc" }
 edc-sts-api = { module = "org.eclipse.edc:identity-trust-sts-api", version.ref = "edc" }
 edc-sts-accountprovisioner = { module = "org.eclipse.edc:sts-account-provisioner", version.ref = "edc" }
+edc-sts-accountservice-local = { module = "org.eclipse.edc:sts-account-service-local", version.ref = "edc" }
+edc-sts-accountservice-remote = { module = "org.eclipse.edc:sts-account-service-remote", version.ref = "edc" }
 edc-sts-remote-client = { module = "org.eclipse.edc:identity-trust-sts-remote-client", version.ref = "edc" }
 
 # federated catalog modules
@@ -190,9 +194,9 @@ dcp = ["edc-dcp", "edc-did-core", "edc-did-web", "edc-oauth2-client", "edc-dcp-c
 sql-edc = ["edc-sql-assetindex", "edc-sql-contractdef", "edc-sql-contractneg", "edc-sql-policydef", "edc-sql-edrcache", "edc-sql-transferprocess", "edc-sql-dataplane-instancestore", "edc-sql-core", "edc-sql-lease", "edc-sql-pool", "edc-sql-transactionlocal", "postgres"]
 sql-edc-dataplane = ["edc-sql-accesstokendata", "edc-sql-dataplane", "edc-sql-core", "edc-sql-lease", "edc-sql-pool", "edc-sql-transactionlocal", "edc-sql-dataplane-instancestore", "postgres"]
 
-sql-ih = ["edc-sql-ih-credstore-sql", "edc-sql-ih-didstore-sql", "edc-sql-ih-keypairstore-sql", "edc-sql-ih-pcstore-sql", "edc-sql-core", "edc-sql-pool", "edc-sql-transactionlocal", "postgres"]
+sql-ih = ["edc-sql-ih-credstore-sql", "edc-sql-ih-didstore-sql", "edc-sql-ih-keypairstore-sql", "edc-sql-ih-pcstore-sql", "edc-sql-ih-stsstore-sql", "edc-sql-core", "edc-sql-pool", "edc-sql-transactionlocal", "postgres"]
 
-sts = ["edc-sts-core", "edc-sts-api", "edc-sts-accountprovisioner", "edc-sts-spi", "edc-sts"]
+sts = ["edc-sts-core", "edc-sts-api", "edc-sts-accountprovisioner", "edc-sts-spi", "edc-sts", "edc-sts-accountservice-local"]
 
 sql-fc = ["edc-fc-cache-sql"]
 

--- a/launchers/identity-hub/build.gradle.kts
+++ b/launchers/identity-hub/build.gradle.kts
@@ -24,9 +24,9 @@ dependencies {
     if (project.properties.getOrDefault("persistence", "false") == "true") {
         runtimeOnly(libs.edc.vault.hashicorp)
         runtimeOnly(libs.bundles.sql.ih)
-        runtimeOnly(libs.bundles.sts)
         println("This runtime compiles with an internal STS, Hashicorp Vault and PostgreSQL. You will need properly configured Postgres and HCV instances.")
     }
+    runtimeOnly(libs.bundles.sts)
     runtimeOnly(project(":extensions:superuser-seed"))
 
     runtimeOnly(libs.bundles.identity.api)


### PR DESCRIPTION
## What this PR changes/adds

adds the newly created STS account service (local) module

## Why it does that

automatic STS Account provisioning

## Further notes

also adds the SQL STS Account Store module

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
