### PR TITLE
chore: rename WF, remove newman install

### DIFF
--- a/.github/workflows/test-controlplane-management.yml
+++ b/.github/workflows/test-controlplane-management.yml
@@ -17,7 +17,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-name: Run Newman Test for the Control Plane Management
+name: Run API tests (postman)
 
 on:
   push:
@@ -87,16 +87,6 @@ jobs:
           chmod +x seed-k8s.sh
           ./seed-k8s.sh
           
-          
-          
-      - name: "Install npm"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: "Install Newman"
-        run: npm install -g newman
-
       - name: "Run Newman"
         working-directory: ./deployment/postman
         run: |-


### PR DESCRIPTION
## What this PR changes/adds

updates the workflow to be in line with other WF names
removes NPM and newman install

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
