### PR TITLE
chore: fixes catalog server boot faulire

### DIFF
--- a/launchers/catalog-server/build.gradle.kts
+++ b/launchers/catalog-server/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     runtimeOnly(libs.edc.api.management.config)
     runtimeOnly(libs.edc.controlplane.core) //default store impls, etc.
     runtimeOnly(libs.edc.controlplane.services) // aggregate services
+    runtimeOnly(libs.edc.core.edrstore) 
     runtimeOnly(libs.edc.dsp) // protocol webhook
     runtimeOnly(libs.bundles.dcp) // DCP protocol impl
     runtimeOnly(libs.edc.api.dsp.config) // json-ld expansion


### PR DESCRIPTION
## What this PR changes/adds

Since the `management-api` bom includes the `edr-api`, this PR adds also the EDR store as dependency for the catalog server 


