### PR TITLE
fix: use new type-based Policy evaluation framework

### DIFF
--- a/extensions/dcp-impl/build.gradle.kts
+++ b/extensions/dcp-impl/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.edc.dcp.core)
     implementation(libs.edc.spi.identity.trust)
     implementation(libs.edc.spi.transform)
+    implementation(libs.edc.spi.catalog)
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.lib.jws2020)
     implementation(libs.edc.lib.transform)

--- a/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DcpPatchExtension.java
+++ b/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DcpPatchExtension.java
@@ -14,13 +14,18 @@
 
 package org.eclipse.edc.demo.dcp.core;
 
-import org.eclipse.edc.iam.identitytrust.core.DcpScopeExtractorExtension;
+import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractorRegistry;
 import org.eclipse.edc.iam.identitytrust.spi.verification.SignatureSuiteRegistry;
 import org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.validation.TrustedIssuerRegistry;
+import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
+import org.eclipse.edc.policy.context.request.spi.RequestTransferProcessPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -64,11 +69,11 @@ public class DcpPatchExtension implements ServiceExtension {
         trustedIssuerRegistry.register(new Issuer("did:example:dataspace-issuer", Map.of()), WILDCARD);
 
         // register a default scope provider
-        var contextMappingFunction = new DefaultScopeMappingFunction(Set.of(
-                "org.eclipse.edc.vc.type:MembershipCredential:read"));
-        policyEngine.registerPostValidator(DcpScopeExtractorExtension.CATALOG_REQUEST_SCOPE, contextMappingFunction);
-        policyEngine.registerPostValidator(DcpScopeExtractorExtension.NEGOTIATION_REQUEST_SCOPE, contextMappingFunction);
-        policyEngine.registerPostValidator(DcpScopeExtractorExtension.TRANSFER_PROCESS_REQUEST_SCOPE, contextMappingFunction);
+        var contextMappingFunction = new DefaultScopeMappingFunction(Set.of("org.eclipse.edc.vc.type:MembershipCredential:read"));
+
+        policyEngine.registerPostValidator(RequestCatalogPolicyContext.class, contextMappingFunction::apply);
+        policyEngine.registerPostValidator(RequestContractNegotiationPolicyContext.class, contextMappingFunction::apply);
+        policyEngine.registerPostValidator(RequestTransferProcessPolicyContext.class, contextMappingFunction::apply);
 
 
         //register scope extractor

--- a/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DcpPatchExtension.java
+++ b/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DcpPatchExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.demo.dcp.core;
 
-import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
 import org.eclipse.edc.iam.identitytrust.spi.scope.ScopeExtractorRegistry;
 import org.eclipse.edc.iam.identitytrust.spi.verification.SignatureSuiteRegistry;
 import org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants;
@@ -24,8 +23,6 @@ import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestTransferProcessPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
-import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
-import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.system.ServiceExtension;

--- a/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DefaultScopeMappingFunction.java
+++ b/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DefaultScopeMappingFunction.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.demo.dcp.core;
 
+import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.RequestScope;
@@ -23,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-public class DefaultScopeMappingFunction implements BiFunction<Policy, PolicyContext, Boolean> {
+public class DefaultScopeMappingFunction implements PolicyValidatorRule<RequestPolicyContext> {
     private final Set<String> defaultScopes;
 
     public DefaultScopeMappingFunction(Set<String> defaultScopes) {
@@ -31,11 +33,8 @@ public class DefaultScopeMappingFunction implements BiFunction<Policy, PolicyCon
     }
 
     @Override
-    public Boolean apply(Policy policy, PolicyContext policyContext) {
-        var requestScopeBuilder = policyContext.getContextData(RequestScope.Builder.class);
-        if (requestScopeBuilder == null) {
-            throw new EdcException("%s not set in policy context".formatted(RequestScope.Builder.class));
-        }
+    public Boolean apply(Policy policy, RequestPolicyContext requestPolicyContext) {
+        var requestScopeBuilder = requestPolicyContext.requestScopeBuilder();
         var rq = requestScopeBuilder.build();
         var existingScope = rq.getScopes();
         var newScopes = new HashSet<>(defaultScopes);

--- a/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DefaultScopeMappingFunction.java
+++ b/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/core/DefaultScopeMappingFunction.java
@@ -15,15 +15,11 @@
 package org.eclipse.edc.demo.dcp.core;
 
 import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.iam.RequestScope;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.BiFunction;
 
 public class DefaultScopeMappingFunction implements PolicyValidatorRule<RequestPolicyContext> {
     private final Set<String> defaultScopes;

--- a/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/policy/DataAccessLevelFunction.java
+++ b/extensions/dcp-impl/src/main/java/org/eclipse/edc/demo/dcp/policy/DataAccessLevelFunction.java
@@ -14,7 +14,10 @@
 
 package org.eclipse.edc.demo.dcp.policy;
 
-import org.eclipse.edc.policy.engine.spi.AtomicConstraintFunction;
+import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
+import org.eclipse.edc.connector.controlplane.contract.spi.policy.ContractNegotiationPolicyContext;
+import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
 import org.eclipse.edc.policy.engine.spi.PolicyContext;
 import org.eclipse.edc.policy.model.Duty;
 import org.eclipse.edc.policy.model.Operator;
@@ -23,17 +26,44 @@ import org.eclipse.edc.spi.agent.ParticipantAgent;
 import java.util.Map;
 import java.util.Objects;
 
-public class DataAccessLevelFunction extends AbstractCredentialEvaluationFunction implements AtomicConstraintFunction<Duty> {
+public abstract class DataAccessLevelFunction<C extends PolicyContext> extends AbstractCredentialEvaluationFunction implements AtomicConstraintRuleFunction<Duty, C> {
 
     private static final String DATAPROCESSOR_CRED_TYPE = "DataProcessorCredential";
 
+    public static DataAccessLevelFunction<TransferProcessPolicyContext> createForTransferProcess() {
+        return new DataAccessLevelFunction<>() {
+            @Override
+            protected ParticipantAgent getAgent(TransferProcessPolicyContext policyContext) {
+                return policyContext.agent();
+            }
+        };
+    }
+
+    public static DataAccessLevelFunction<ContractNegotiationPolicyContext> createForNegotiation() {
+        return new DataAccessLevelFunction<>() {
+            @Override
+            protected ParticipantAgent getAgent(ContractNegotiationPolicyContext policyContext) {
+                return policyContext.agent();
+            }
+        };
+    }
+
+    public static DataAccessLevelFunction<CatalogPolicyContext> createForCatalog() {
+        return new DataAccessLevelFunction<>() {
+            @Override
+            protected ParticipantAgent getAgent(CatalogPolicyContext policyContext) {
+                return policyContext.agent();
+            }
+        };
+    }
+
     @Override
-    public boolean evaluate(Operator operator, Object rightOperand, Duty duty, PolicyContext policyContext) {
+    public boolean evaluate(Operator operator, Object rightOperand, Duty duty, C policyContext) {
         if (!operator.equals(Operator.EQ)) {
             policyContext.reportProblem("Cannot evaluate operator %s, only %s is supported".formatted(operator, Operator.EQ));
             return false;
         }
-        var pa = policyContext.getContextData(ParticipantAgent.class);
+        var pa = getAgent(policyContext);
         if (pa == null) {
             policyContext.reportProblem("ParticipantAgent not found on PolicyContext");
             return false;
@@ -56,12 +86,10 @@ public class DataAccessLevelFunction extends AbstractCredentialEvaluationFunctio
                     return version != null && Objects.equals(level, rightOperand);
                 });
 
-        
+
     }
 
-    public String key() {
-        return "DataAccess.level";
-    }
+    protected abstract ParticipantAgent getAgent(C policyContext);
 
     @SuppressWarnings("unchecked")
     private <T> T getClaim(String postfix, Map<String, Object> claims) {
@@ -69,5 +97,13 @@ public class DataAccessLevelFunction extends AbstractCredentialEvaluationFunctio
                 .findFirst()
                 .map(Map.Entry::getValue)
                 .orElse(null);
+    }
+
+    private static class ForCatalog extends DataAccessLevelFunction<CatalogPolicyContext> {
+
+        @Override
+        protected ParticipantAgent getAgent(CatalogPolicyContext policyContext) {
+            return policyContext.agent();
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref 
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-identity-trust = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
 edc-spi-transform = { module = "org.eclipse.edc:transform-spi", version.ref = "edc" }
+edc-spi-catalog = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
 edc-spi-identity-did = { module = "org.eclipse.edc:identity-did-spi", version.ref = "edc" }
 


### PR DESCRIPTION
## What this PR changes/adds

fixes compile errors that were introduced by some upstream changes.

now, MVD already uses the new type-based Policy evaluation framework.

## Why it does that

fix compile errors, avoid technical debt

## Linked Issue(s)

Closes #360

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
