### PR TITLE
chore: update run configs and EDC version

### DIFF
--- a/.run/Connector Consumer Corp.run.xml
+++ b/.run/Connector Consumer Corp.run.xml
@@ -1,12 +1,13 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Connector Consumer Corp" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-22" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/deployment/assets/env/consumer_connector.env" />
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.runtime-embedded.main" />
+    <option name="PROGRAM_PARAMETERS" value="--log-level=debug" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Connector _provider-manufacturing_.run.xml
+++ b/.run/Connector _provider-manufacturing_.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Connector &quot;provider-manufacturing&quot;" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-22" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/deployment/assets/env/provider_connector_manufacturing.env" />

--- a/.run/IdentityHub Consumer Corp.run.xml
+++ b/.run/IdentityHub Consumer Corp.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="IdentityHub Consumer Corp" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-22" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/deployment/assets/env/consumer_identityhub.env" />

--- a/.run/Provider Catalog Server.run.xml
+++ b/.run/Provider Catalog Server.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Provider Catalog Server" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-22" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/deployment/assets/env/provider_catalogserver.env" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
     }
 }
 
-val annotationProcessorVersion: String by project
+val edcGradlePluginsVersion: String by project
 
 allprojects {
     apply(plugin = "${group}.edc-build")
@@ -36,7 +36,7 @@ allprojects {
     // configure which version of the annotation processor to use. defaults to the same version as the plugin
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
         outputDirectory.set(project.layout.buildDirectory.asFile)
-        processorVersion.set(annotationProcessorVersion)
+        processorVersion.set(edcGradlePluginsVersion)
     }
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 group=org.eclipse.edc
-version=0.10.0-SNAPSHOT
+version=0.11.0-SNAPSHOT
 
-edcGradlePluginsVersion=0.10.0-SNAPSHOT
-annotationProcessorVersion=0.10.0-SNAPSHOT
+edcGradlePluginsVersion=0.11.0-SNAPSHOT


### PR DESCRIPTION
## What this PR changes/adds

updates the JDK version of the runconfigs to a LTS version, updates to use latest EDC snapshots

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
