### PR TITLE
Improve the MVD tutorial: Textual and programmatic fixes/additions

### DIFF
--- a/.run/Connector Consumer Corp.run.xml
+++ b/.run/Connector Consumer Corp.run.xml
@@ -8,6 +8,7 @@
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.runtime-embedded.main" />
     <option name="PROGRAM_PARAMETERS" value="--log-level=debug" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Connector _provider-manufacturing_.run.xml
+++ b/.run/Connector _provider-manufacturing_.run.xml
@@ -7,6 +7,7 @@
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.runtime-embedded.main" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Connector _provider-qna_.run.xml
+++ b/.run/Connector _provider-qna_.run.xml
@@ -6,6 +6,7 @@
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.runtime-embedded.main" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/IdentityHub Consumer Corp.run.xml
+++ b/.run/IdentityHub Consumer Corp.run.xml
@@ -7,6 +7,7 @@
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.identity-hub.main" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/IdentityHub Provider Corp.run.xml
+++ b/.run/IdentityHub Provider Corp.run.xml
@@ -6,6 +6,7 @@
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.identity-hub.main" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Provider Catalog Server.run.xml
+++ b/.run/Provider Catalog Server.run.xml
@@ -7,6 +7,7 @@
     </option>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.edc.boot.system.runtime.BaseRuntime" />
     <module name="mvd.launchers.catalog-server.main" />
+    <shortenClasspath name="ARGS_FILE" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/README.md
+++ b/README.md
@@ -284,10 +284,9 @@ connector-to-connector communication to fail.
 
 All REST requests made from the script are available in the [Postman
 collection](./deployment/postman/MVD.postman_collection.json). With the [HTTP
-Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) and [Import from Postman
-Collections](https://plugins.jetbrains.com/plugin/22438-import-from-postman-collections) plugins, the Postman collection
-can be imported and then executed by means of the [environment file](./deployment/postman/http-client.env.json),
-selecting the "Local" environment.
+Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) plugin, the Postman collection
+can be imported (right click on the file in IntelliJ, then `Convert Collection to .http File`).
+Then, open the generated .http file in IntelliJ and run in IntelliJ, select "run with environment: Local" ([environment file](./deployment/postman/http-client.env.json)), and run chosen requests.
 
 Please read [chapter 7](#7-executing-rest-requests-using-postman) for details.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ All REST requests made from the script are available in the [Postman
 collection](./deployment/postman/MVD.postman_collection.json). With the [HTTP
 Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) plugin, the Postman collection
 can be imported (right click on the file in IntelliJ, then `Convert Collection to .http File`).
-Then, open the generated .http file in IntelliJ and run in IntelliJ, select "run with environment: Local" ([environment file](./deployment/postman/http-client.env.json)), and run chosen requests.
+Then, open the generated .http file in IntelliJ, do a search-and-replace (change all `Content-Type: text/plain` to `Content-Type: application/json`), select "run with environment: Local" ([environment file](./deployment/postman/http-client.env.json)), and run chosen requests.
 
 Please read [chapter 7](#7-executing-rest-requests-using-postman) for details.
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ All run configs take their configuration from `*.env` files which are located in
 ### 4.3 Seeding the dataspace
 
 DID documents are dynamically generated when "seeding" the data, specifically when creating the `ParticipantContext`
-objects in IdentityHub. This is automatically being done by a script `seed.sh`.
+objects in IdentityHub. This is automatically being done by a script `seed.sh`. Windows user might need to configure a shell interpreter in IntelliJ first, for which they could use `C:\WINDOWS\system32\CMD.exe` with script option `/C`.
 
 After executing the `dataspace` run config in Intellij, be sure to **execute the `seed.sh` script after all the runtimes
 have started**. Omitting to do so will leave the dataspace in an uninitialized state and cause all


### PR DESCRIPTION
## What this PR changes/adds

1. This PR modifies text passages and code snippets in the README.md.
3. It also adds `<shortenClasspath name="ARGS_FILE" />` to all six run configurations.

## Why it does that

1. README: Improve readability and flow, fix possible errors.
2. Run configurations: Avoid "Command line is too long" error (esp. on Windows).
