### PR TITLE
chore: fix after upstream changes holder renaming

### DIFF
--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -6369,7 +6369,7 @@
 											}
 										},
 										"url": {
-											"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/issuers/{{ISSUER_CONTEXT_ID}}/issuanceprocesses/query",
+											"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/participants/{{ISSUER_CONTEXT_ID}}/issuanceprocesses/query",
 											"host": [
 												"{{ISSUER_ADMIN_URL}}"
 											],
@@ -6377,7 +6377,7 @@
 												"api",
 												"admin",
 												"v1alpha",
-												"issuers",
+												"participants",
 												"{{ISSUER_CONTEXT_ID}}",
 												"issuanceprocesses",
 												"query"
@@ -6400,7 +6400,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"did\": \"{{CONSUMER_ID}}\",\n    \"participantId\": \"{{CONSUMER_ID}}\",\n    \"name\": \"{{CONSUMER_NAME}}\"\n}",
+									"raw": "{\n    \"did\": \"{{CONSUMER_ID}}\",\n    \"holderId\": \"{{CONSUMER_ID}}\",\n    \"name\": \"{{CONSUMER_NAME}}\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6408,7 +6408,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/participants",
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/holders",
 									"host": [
 										"{{ISSUER_ADMIN_URL}}"
 									],
@@ -6416,10 +6416,10 @@
 										"api",
 										"admin",
 										"v1alpha",
-										"participants"
+										"holders"
 									]
 								},
-								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/participants' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7083\", \"participantId\": \"did:web:localhost%3A7083\", \"name\": \"Consumer Participant\"}'"
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/holders' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7083\", \"participantId\": \"did:web:localhost%3A7083\", \"name\": \"Consumer Participant\"}'"
 							},
 							"response": []
 						},
@@ -6430,7 +6430,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"did\": \"{{PROVIDER_ID}}\",\n    \"participantId\": \"{{PROVIDER_ID}}\",\n    \"name\": \"{{PROVIDER_NAME}}\"\n}",
+									"raw": "{\n    \"did\": \"{{PROVIDER_ID}}\",\n    \"holderId\": \"{{PROVIDER_ID}}\",\n    \"name\": \"{{PROVIDER_NAME}}\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6438,7 +6438,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/participants",
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/holders",
 									"host": [
 										"{{ISSUER_ADMIN_URL}}"
 									],
@@ -6446,10 +6446,10 @@
 										"api",
 										"admin",
 										"v1alpha",
-										"participants"
+										"holders"
 									]
 								},
-								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/participants' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7093\", \"participantId\": \"did:web:localhost%3A7093\", \"name\": \"Provider Participant\"}'"
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/holders' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7093\", \"participantId\": \"did:web:localhost%3A7093\", \"name\": \"Provider Participant\"}'"
 							},
 							"response": []
 						},

--- a/seed-k8s.sh
+++ b/seed-k8s.sh
@@ -132,7 +132,7 @@ DATA_ISSUER=$(jq -n --arg pem "$PEM_ISSUER" '{
             "serviceEndpoints":[
               {
                  "type": "IssuerService",
-                 "serviceEndpoint": "http://dataspace-issuer-service:10012/api/issuance/v1alpha/issuers/ZGlkOndlYjpkYXRhc3BhY2UtaXNzdWVyLXNlcnZpY2UlM0ExMDAxNjppc3N1ZXI=",
+                 "serviceEndpoint": "http://dataspace-issuer-service:10012/api/issuance/v1alpha/participants/ZGlkOndlYjpkYXRhc3BhY2UtaXNzdWVyLXNlcnZpY2UlM0ExMDAxNjppc3N1ZXI=",
                  "id": "issuer-service-1"
               }
             ],

--- a/seed.sh
+++ b/seed.sh
@@ -151,7 +151,7 @@ DATA_ISSUER=$(jq -n --arg pem "$PEM_ISSUER" '{
             "serviceEndpoints":[
               {
                  "type": "IssuerService",
-                 "serviceEndpoint": "http://localhost:10012/api/issuance/v1alpha/issuers/ZGlkOndlYjpsb2NhbGhvc3QlM0ExMDEwMA==",
+                 "serviceEndpoint": "http://localhost:10012/api/issuance/v1alpha/participants/ZGlkOndlYjpsb2NhbGhvc3QlM0ExMDEwMA==",
                  "id": "issuer-service-1"
               }
             ],


### PR DESCRIPTION
## What this PR changes/adds

 fix after upstream changes 

- restore `participants` path for admin and dcp API
- changes participant -> holder

## Why it does that

keeping up with upstream changes

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
