### PR TITLE
feat: seed issuer for database attestations

### DIFF
--- a/deployment/issuer.tf
+++ b/deployment/issuer.tf
@@ -27,11 +27,11 @@ module "dataspace-issuer" {
 
 # Postgres database for the consumer
 module "dataspace-issuer-postgres" {
-  depends_on = [kubernetes_config_map.issuer-initdb-config]
-  source        = "./modules/postgres"
-  instance-name = "issuer"
+  depends_on       = [kubernetes_config_map.issuer-initdb-config]
+  source           = "./modules/postgres"
+  instance-name    = "issuer"
   init-sql-configs = ["issuer-initdb-config"]
-  namespace     = kubernetes_namespace.ns.metadata.0.name
+  namespace        = kubernetes_namespace.ns.metadata.0.name
 }
 
 # DB initialization for the EDC database

--- a/deployment/issuer.tf
+++ b/deployment/issuer.tf
@@ -27,11 +27,11 @@ module "dataspace-issuer" {
 
 # Postgres database for the consumer
 module "dataspace-issuer-postgres" {
-  depends_on       = [kubernetes_config_map.issuer-initdb-config]
-  source           = "./modules/postgres"
-  instance-name    = "issuer"
+  depends_on = [kubernetes_config_map.issuer-initdb-config]
+  source        = "./modules/postgres"
+  instance-name = "issuer"
   init-sql-configs = ["issuer-initdb-config"]
-  namespace        = kubernetes_namespace.ns.metadata.0.name
+  namespace     = kubernetes_namespace.ns.metadata.0.name
 }
 
 # DB initialization for the EDC database
@@ -45,6 +45,24 @@ resource "kubernetes_config_map" "issuer-initdb-config" {
         CREATE USER issuer WITH ENCRYPTED PASSWORD 'issuer' SUPERUSER;
         CREATE DATABASE issuer;
         \c issuer issuer
+
+        create table if not exists membership_attestations
+        (
+            membership_type       integer   default 0,
+            holder_id             varchar                             not null,
+            membership_start_date timestamp default now()             not null,
+            id                    varchar   default gen_random_uuid() not null
+                constraint attestations_pk
+                    primary key
+        );
+
+        create unique index if not exists membership_attestation_holder_id_uindex
+          on membership_attestations (holder_id);
+
+        -- seed the consumer and provider into the attestations DB, so that they can request FoobarCredentials sourcing
+        -- information from the database
+        INSERT INTO membership_attestations (membership_type, holder_id) VALUES (1, 'did:web:consumer-identityhub%3A7083:consumer');
+        INSERT INTO membership_attestations (membership_type, holder_id) VALUES (2, 'did:web:provider-identityhub%3A7083:provider');
       EOT
   }
 }

--- a/deployment/modules/issuer/main.tf
+++ b/deployment/modules/issuer/main.tf
@@ -13,7 +13,7 @@
 
 resource "kubernetes_deployment" "issuerservice" {
   metadata {
-    name      = lower(var.humanReadableName)
+    name = lower(var.humanReadableName)
     namespace = var.namespace
     labels = {
       App = lower(var.humanReadableName)
@@ -137,12 +137,19 @@ resource "kubernetes_config_map" "issuerservice-config" {
     WEB_HTTP_DID_PORT                       = var.ports.did
     WEB_HTTP_DID_PATH                       = "/"
 
-    JAVA_TOOL_OPTIONS                  = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.debug}"
-    EDC_VAULT_HASHICORP_URL            = var.vault-url
-    EDC_VAULT_HASHICORP_TOKEN          = var.vault-token
-    EDC_DATASOURCE_DEFAULT_URL         = var.database.url
-    EDC_DATASOURCE_DEFAULT_USER        = var.database.user
-    EDC_DATASOURCE_DEFAULT_PASSWORD    = var.database.password
+    JAVA_TOOL_OPTIONS               = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.debug}"
+    EDC_VAULT_HASHICORP_URL         = var.vault-url
+    EDC_VAULT_HASHICORP_TOKEN       = var.vault-token
+    EDC_DATASOURCE_DEFAULT_URL      = var.database.url
+    EDC_DATASOURCE_DEFAULT_USER     = var.database.user
+    EDC_DATASOURCE_DEFAULT_PASSWORD = var.database.password
+
+    # even though we have a default data source, we need a named datasource for the DatabaseAttestationSource, because
+    # that is configured in the AttestationDefinition
+    EDC_DATASOURCE_MEMBERSHIP_URL      = var.database.url
+    EDC_DATASOURCE_MEMBERSHIP_USER     = var.database.user
+    EDC_DATASOURCE_MEMBERSHIP_PASSWORD = var.database.password
+
     EDC_SQL_SCHEMA_AUTOCREATE          = true
     EDC_IAM_ACCESSTOKEN_JTI_VALIDATION = true
     EDC_IAM_DID_WEB_USE_HTTPS          = false

--- a/deployment/modules/issuer/main.tf
+++ b/deployment/modules/issuer/main.tf
@@ -13,7 +13,7 @@
 
 resource "kubernetes_deployment" "issuerservice" {
   metadata {
-    name = lower(var.humanReadableName)
+    name      = lower(var.humanReadableName)
     namespace = var.namespace
     labels = {
       App = lower(var.humanReadableName)

--- a/deployment/postman/MVD K8S.postman_environment.json
+++ b/deployment/postman/MVD K8S.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "9432baf7-0849-46e4-a1a7-dece247a41be",
+	"id": "9330e6b5-fffa-40a9-8835-5e76233f9ccd",
 	"name": "MVD K8S",
 	"values": [
 		{
@@ -11,12 +11,6 @@
 		{
 			"key": "CS_URL",
 			"value": "http://localhost/consumer/cs/",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "PROVIDER_ID",
-			"value": "did:web:provider-identityhub%3A7083:provider",
 			"type": "default",
 			"enabled": true
 		},
@@ -33,26 +27,38 @@
 			"enabled": true
 		},
 		{
-			"key": "PROVIDER_DSP_URL",
-			"value": "http://provider-qna-controlplane:8082",
-			"type": "default",
-			"enabled": true
-		},
-		{
 			"key": "PROVIDER_PUBLIC_API",
 			"value": "http://localhost/provider-qna/public",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "ISSUER_ADMIN_URL",
-			"value": "http://localhost/issuer/ad",
+			"key": "PROVIDER_DSP_URL",
+			"value": "http://provider-qna-controlplane:8082",
 			"type": "default",
 			"enabled": true
 		},
 		{
-			"key": "ISSUER_CONTEXT_ID",
-			"value": "ZGlkOndlYjpkYXRhc3BhY2UtaXNzdWVyLXNlcnZpY2UlM0ExMDAxNjppc3N1ZXI",
+			"key": "PROVIDER_ID",
+			"value": "did:web:provider-identityhub%3A7083:provider",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "PROVIDER_NAME",
+			"value": "MVD Provider Participant",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CONSUMER_ID",
+			"value": "did:web:consumer-identityhub%3A7083:consumer",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CONSUMER_NAME",
+			"value": "MVD Consumer Participant",
 			"type": "default",
 			"enabled": true
 		},
@@ -61,9 +67,63 @@
 			"value": "did:web:dataspace-issuer-service%3A10016:issuer",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "ISSUER_BASE_URL",
+			"value": "http://localhost/issuer/ad",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ISSUER_ADMIN_URL",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "PARTICIPANT_ID_BASE64",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "REQUEST_ID",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "POLICY_ID_ASSET_1",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "CONTRACT_NEGOTIATION_ID",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "CONTRACT_AGREEMENT_ID",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "TRANSFER_PROCESS_ID",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "AUTHORIZATION",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-07-19T12:19:41.675Z",
-	"_postman_exported_using": "Postman/11.4.0"
+	"_postman_exported_at": "2025-03-05T06:26:50.206Z",
+	"_postman_exported_using": "Postman/11.34.4"
 }

--- a/deployment/postman/MVD Local Development.postman_environment.json
+++ b/deployment/postman/MVD Local Development.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "35c096d9-84c2-499f-8ed0-8bcf3275370b",
+	"id": "448d5e51-e4f9-4b2a-96ea-1054aab52c1d",
 	"name": "MVD Local Development",
 	"values": [
 		{
@@ -11,12 +11,6 @@
 		{
 			"key": "CS_URL",
 			"value": "http://localhost:7082",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "PROVIDER_ID",
-			"value": "did:web:localhost%3A7093",
 			"type": "default",
 			"enabled": true
 		},
@@ -45,13 +39,67 @@
 			"enabled": true
 		},
 		{
-			"key": "ISSUER_ADMIN_URL",
-			"value": "http://localhost:10013",
+			"key": "ISSUER_BASE_URL",
+			"value": "",
 			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ISSUER_ADMIN_URL",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CONSUMER_ID",
+			"value": "did:web:localhost%3A7083",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "CONSUMER_NAME",
+			"value": "MVD Consumer Participant",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "PROVIDER_ID",
+			"value": "did:web:localhost%3A7093",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "PROVIDER_NAME",
+			"value": "MVD Provider Participant",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "ISSUER_DID",
+			"value": "did:web:localhost%3A10100",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "POLICY_ID_ASSET_1",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "PARTICIPANT_ID_BASE64",
+			"value": "ZGlkOndlYjpsb2NhbGhvc3QlM0E3MDgz",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "REQUEST_ID",
+			"value": "",
+			"type": "any",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-07-19T12:19:50.250Z",
-	"_postman_exported_using": "Postman/11.4.0"
+	"_postman_exported_at": "2025-03-05T06:26:44.509Z",
+	"_postman_exported_using": "Postman/11.34.4"
 }

--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -2142,7 +2142,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{CS_URL}}/api/identity/v1alpha/participants/ZGlkOndlYjpsb2NhbGhvc3QlM0E3MDgz/credentials?type=DemoCredential",
+									"raw": "{{CS_URL}}/api/identity/v1alpha/participants/ZGlkOndlYjpsb2NhbGhvc3QlM0E3MDgz/credentials?type=FoobarCredential",
 									"host": [
 										"{{CS_URL}}"
 									],
@@ -2157,7 +2157,7 @@
 									"query": [
 										{
 											"key": "type",
-											"value": "DemoCredential"
+											"value": "FoobarCredential"
 										}
 									]
 								}
@@ -2188,7 +2188,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"issuerDid\": \"{{ISSUER_DID}}\",\n    \"holderPid\": \"credential-request-1\",\n    \"credentials\": [{\n        \"format\": \"VC1_0_JWT\",\n        \"credentialType\": \"DemoCredential\"\n    }]\n}",
+									"raw": "{\n    \"issuerDid\": \"{{ISSUER_DID}}\",\n    \"holderPid\": \"credential-request-1\",\n    \"credentials\": [{\n        \"format\": \"VC1_0_JWT\",\n        \"credentialType\": \"FoobarCredential\"\n    }]\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6b6afa14-0bb9-472d-8a79-32e788253e4c",
+		"_postman_id": "cfcc016d-f3b8-4962-a217-511e5d2906e4",
 		"name": "MVD",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "647585"
@@ -6460,7 +6460,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"attestationType\": \"demo\",\n  \"configuration\": {\n  },\n  \"id\": \"demo-attestation-def-1\"\n}",
+									"raw": "{\n    \"attestationType\": \"database\",\n    \"configuration\": {\n        \"tableName\": \"membership_attestations\",\n        \"dataSourceName\": \"membership\",\n        \"idColumn\": \"holder_id\"\n    },\n    \"id\": \"db-attestation-def-1\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6490,7 +6490,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"attestations\": [\n        \"demo-attestation-def-1\"\n    ],\n    \"credentialType\": \"DemoCredential\",\n    \"dataModel\": \"V_1_1\",\n    \"id\": \"demo-credential-def-1\",\n    \"jsonSchema\": \"{}\",\n    \"jsonSchemaUrl\": \"https://example.com/schema/demo-credential.json\",\n    \"mappings\": [\n        {\n            \"input\": \"participant.name\",\n            \"output\": \"credentialSubject.name\",\n            \"required\": \"true\"\n        }\n    ],\n    \"rules\": [\n        {\n            \"type\": \"expression\",\n            \"configuration\": {\n                \"claim\": \"onboarding.signedDocuments\",\n                \"operator\": \"eq\",\n                \"value\": true\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"attestations\": [\n        \"db-attestation-def-1\"\n    ],\n    \"credentialType\": \"FoobarCredential\",\n    \"dataModel\": \"V_1_1\",\n    \"id\": \"demo-credential-def-2\",\n    \"jsonSchema\": \"{}\",\n    \"jsonSchemaUrl\": \"https://example.com/schema/demo-credential.json\",\n    \"mappings\": [\n        {\n            \"input\": \"membership_type\",\n            \"output\": \"credentialSubject.membershipType\",\n            \"required\": \"true\"\n        },\n        {\n            \"input\": \"membership_start_date\",\n            \"output\": \"credentialSubject.membershipStartDate\",\n            \"required\": true\n        }\n    ],\n    \"rules\": []\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/deployment/postman/MVD.postman_collection.json
+++ b/deployment/postman/MVD.postman_collection.json
@@ -6391,7 +6391,7 @@
 					]
 				},
 				{
-					"name": "Seed Issuer",
+					"name": "Seed Issuer SQL",
 					"item": [
 						{
 							"name": "Create consumer participant",
@@ -6491,6 +6491,155 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n    \"attestations\": [\n        \"db-attestation-def-1\"\n    ],\n    \"credentialType\": \"FoobarCredential\",\n    \"dataModel\": \"V_1_1\",\n    \"id\": \"demo-credential-def-2\",\n    \"jsonSchema\": \"{}\",\n    \"jsonSchemaUrl\": \"https://example.com/schema/demo-credential.json\",\n    \"mappings\": [\n        {\n            \"input\": \"membership_type\",\n            \"output\": \"credentialSubject.membershipType\",\n            \"required\": \"true\"\n        },\n        {\n            \"input\": \"membership_start_date\",\n            \"output\": \"credentialSubject.membershipStartDate\",\n            \"required\": true\n        }\n    ],\n    \"rules\": []\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/credentialdefinitions",
+									"host": [
+										"{{ISSUER_ADMIN_URL}}"
+									],
+									"path": [
+										"api",
+										"admin",
+										"v1alpha",
+										"credentialdefinitions"
+									]
+								},
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/credentialdefinitions' \\\n-H 'Content-Type: application/json' \\\n-d '{\n      \"attestations\": [\n        \"demo-attestation-def-1\"\n      ],\n      \"credentialType\": \"DemoCredential\",\n      \"dataModel\": \"V_1_1\",\n      \"id\": \"demo-credential-def-1\",\n      \"jsonSchema\": \"\",\n      \"jsonSchemaUrl\": \"https://example.com/schema/demo-credential.json\",\n      \"mappings\": [\n        {\n          \"input\": \"name\",\n          \"output\": \"credentialSubject.name\",\n          \"required\": \"true\"\n        }\n      ],\n      \"rules\": []\n    }'"
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"Status is OK or conflict\", function() {",
+									"  pm.expect(pm.response.code).to.be.oneOf([200, 201, 204, 409])",
+									"})"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Seed Issuer",
+					"item": [
+						{
+							"name": "Create consumer participant",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"did\": \"{{CONSUMER_ID}}\",\n    \"holderId\": \"{{CONSUMER_ID}}\",\n    \"name\": \"{{CONSUMER_NAME}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/holders",
+									"host": [
+										"{{ISSUER_ADMIN_URL}}"
+									],
+									"path": [
+										"api",
+										"admin",
+										"v1alpha",
+										"holders"
+									]
+								},
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/holders' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7083\", \"participantId\": \"did:web:localhost%3A7083\", \"name\": \"Consumer Participant\"}'"
+							},
+							"response": []
+						},
+						{
+							"name": "Create provider participant",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"did\": \"{{PROVIDER_ID}}\",\n    \"holderId\": \"{{PROVIDER_ID}}\",\n    \"name\": \"{{PROVIDER_NAME}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/holders",
+									"host": [
+										"{{ISSUER_ADMIN_URL}}"
+									],
+									"path": [
+										"api",
+										"admin",
+										"v1alpha",
+										"holders"
+									]
+								},
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/holders' \\\n-H 'Content-Type: application/json' \\\n-d '{ \"did\": \"did:web:localhost%3A7093\", \"participantId\": \"did:web:localhost%3A7093\", \"name\": \"Provider Participant\"}'"
+							},
+							"response": []
+						},
+						{
+							"name": "Create attestation definitions",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"attestationType\": \"demo\",\n    \"configuration\": {\n    },\n    \"id\": \"demo-attestation-def-1\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ISSUER_ADMIN_URL}}/api/admin/v1alpha/attestations",
+									"host": [
+										"{{ISSUER_ADMIN_URL}}"
+									],
+									"path": [
+										"api",
+										"admin",
+										"v1alpha",
+										"attestations"
+									]
+								},
+								"description": "Generated from cURL: curl -sL -X POST 'http://localhost:10013/api/admin/v1alpha/attestations' \\\n-H 'Content-Type: application/json' \\\n-d '{\n  \"attestationType\": \"demo\",\n  \"configuration\": {\n  },\n  \"id\": \"demo-attestation-def-1\"\n}'"
+							},
+							"response": []
+						},
+						{
+							"name": "Create credential definitions",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"attestations\": [\n        \"demo-attestation-def-1\"\n    ],\n    \"credentialType\": \"DemoCredential\",\n    \"dataModel\": \"V_1_1\",\n    \"id\": \"demo-credential-def-1\",\n    \"jsonSchema\": \"{}\",\n    \"jsonSchemaUrl\": \"https://example.com/schema/demo-credential.json\",\n    \"mappings\": [\n        {\n            \"input\": \"participant.name\",\n            \"output\": \"credentialSubject.participant_name\",\n            \"required\": \"true\"\n        }\n    ],\n    \"rules\": []\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/seed-k8s.sh
+++ b/seed-k8s.sh
@@ -154,7 +154,7 @@ curl -s --location 'http://127.0.0.1/issuer/cs/api/identity/v1alpha/participants
 
 ## Seed participant data to the issuer service
 newman run \
-  --folder "Seed Issuer" \
+  --folder "Seed Issuer SQL" \
   --env-var "ISSUER_ADMIN_URL=http://127.0.0.1/issuer/ad" \
   --env-var "CONSUMER_ID=did:web:consumer-identityhub%3A7083:consumer" \
   --env-var "CONSUMER_NAME=MVD Consumer Participant" \

--- a/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/issuance/CredentialIssuanceEndToEndTest.java
+++ b/tests/end2end/src/test/java/org/eclipse/edc/demo/tests/issuance/CredentialIssuanceEndToEndTest.java
@@ -58,7 +58,7 @@ public class CredentialIssuanceEndToEndTest {
                           "issuerDid": "%s",
                           "holderPid": "%s",
                           "credentials": [
-                            {"format": "VC1_0_JWT", "credentialType": "DemoCredential"}
+                            {"format": "VC1_0_JWT", "credentialType": "FoobarCredential"}
                           ]
                         }
                         """.formatted(ISSUER_DID, HOLDER_PID))
@@ -88,7 +88,7 @@ public class CredentialIssuanceEndToEndTest {
                 .jsonPath()
                 .getList("verifiableCredential.credential.type");
 
-        assertThat(list).anySatisfy(typesList -> assertThat(typesList).containsExactlyInAnyOrder("DemoCredential", "VerifiableCredential"));
+        assertThat(list).anySatisfy(typesList -> assertThat(typesList).containsExactlyInAnyOrder("FoobarCredential", "VerifiableCredential"));
 
 
     }


### PR DESCRIPTION
## What this PR changes/adds

this PR adopts the `DatabaseAttestationSources` that were introduced in https://github.com/eclipse-edc/IdentityHub/pull/649 by seeding the database and adapting the postman collection

## Why it does that

feature display

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
