### PR TITLE
feat: workflow to create GH Releases and Tags

### DIFF
--- a/.github/actions/push-tag/action.yml
+++ b/.github/actions/push-tag/action.yml
@@ -1,0 +1,93 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Publish Github release and tag"
+description: "Publish Github release and tag"
+inputs:
+  version:
+    required: true
+    description: "The version to be used in the tag and release publication"
+  token:
+    required: true
+    description: "Github token"
+  is_latest:
+    required: true
+    description: "Boolean that defines if a release is latest or not"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Prepare Git Config
+      shell: bash
+      run: |
+        # Prepare git env
+        git config user.name "eclipse-edc-bot"
+        git config user.email "edc-bot@eclipse.org"
+    - name: Create Release Tag
+      id: create_release_tag
+      shell: bash
+      run: |
+        # informative
+        git branch -a
+        git tag
+
+        # Create & push tag
+        git tag ${{ inputs.version }}
+        git push origin ${{ inputs.version }}
+    - name: Create GitHub Release
+      uses: ncipollo/release-action@v1
+      with:
+        generateReleaseNotes: true
+        tag: ${{ inputs.version }}
+        token: ${{ inputs.token }}
+        makeLatest: ${{ inputs.is_latest }}
+        removeArtifacts: false
+    - uses: ./.github/actions/gradle-setup
+    - name: Set new snapshot version
+      if: ${{ inputs.is_latest }}
+      shell: bash
+      run: |
+        # Extract release version
+        IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"${{ inputs.version}}"
+        INC=0
+        # Compute new snapshot version, do not increment snapshot on non-final releases, e.g. -rc1
+        if [ -z $SNAPSHOT ]; then
+          # snapshot
+          echo "${{ inputs.version }} is a final release version, increase patch for next snapshot"
+          INC=1
+        else
+          echo "${{ inputs.version }} is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
+        fi
+
+        VERSION="$RELEASE_VERSION_MAJOR.$((RELEASE_VERSION_MINOR+$INC)).0-SNAPSHOT"
+        SNAPSHOT_VERSION=$VERSION
+
+        # Persist the "version" in the gradle.properties
+        sed -i "s/version=.*/version=$SNAPSHOT_VERSION/g" gradle.properties
+        
+        # Persist the "version" in the version catalog
+        sed -i 's/edc\s*=\s*".*"/edc = "$SNAPSHOT_VERSION"/g' gradle/libs.versions.toml
+
+        # Commit and push to origin main
+        git add gradle.properties
+        git commit --message "Introduce new snapshot version $SNAPSHOT_VERSION"
+
+        git push

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,119 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+---
+name: "Draft Release"
+run-name: "Draft Release ${{ inputs.version }} from ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version of EDC that should be used in this release, e.g. "0.12.0" or "0.13.0-somespecial-SNAPSHOT"'
+        required: true
+
+jobs:
+  validate-and-prepare:
+    name: "Validate that tag does not already exist and prepare branch"
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/') }}
+    outputs:
+      branch_name: ${{ steps.resolve_branch.outputs.branch_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check-tag
+        name: "Check if tag exists"
+        run: |-
+
+          tag=$(git tag -l ${{ inputs.version }})
+
+          if [ ! -z $tag ];
+          then
+            echo "A Git tag $tag already exists! Please delete first or choose another tag."
+            exit 1
+          fi
+      - id: resolve_branch
+        name: "Resolve branch prefix (release or bugfix)"
+        run: |
+          
+          if [[ ${{ github.ref_name }} == "main" ]];
+          then
+            echo "branch_name=release/${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ github.ref }} == refs/tags/* ]]
+          then
+            echo "branch_name=bugfix/${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Ref branch does not match required criteria. Should either be "main" or a tag."
+            exit 1
+          fi
+
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    needs: validate-and-prepare
+    permissions:
+      contents: write
+      packages: write
+      pages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Release or Bugfix branch
+        run: git checkout -b ${{ needs.validate-and-prepare.outputs.branch_name }}
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "eclipse-edc-bot"
+          git config user.email "edc-bot@eclipse.org"
+      - uses: ./.github/actions/gradle-setup
+      - name: Bump version in gradle.properties
+        run: |-
+          # replace the project's (default) version, could be overwritten later with the -Pversion=... flag
+          sed -i  's/version=.*/version=${{ inputs.version }}/g' gradle.properties
+          sed -i  's/edcGradlePluginsVersion=.*/edcGradlePluginsVersion=${{ inputs.version }}/g' gradle.properties
+
+      - name: Bump version in version catalog
+        run: |-
+          sed -i 's/edc\s*=\s*".*"/edc = "${{ inputs.version }}"/g' gradle/libs.versions.toml
+
+      - name: Commit changed files
+        id: make-commit
+        run: |
+          git add gradle.properties gradle/libs.versions.toml
+          git commit --message "Prepare release ${{ inputs.version }}"
+          
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Push new branch
+        run: git push origin ${{ needs.validate-and-prepare.outputs.branch_name }}
+      - name: Create pull request
+        if: ${{ github.ref_name == 'main' }}
+        uses: thomaseizinger/create-pull-request@1.4.0
+        with:
+          head: ${{ needs.validate-and-prepare.outputs.branch_name }}
+          base: main
+          title: Release version ${{ inputs.version }}
+          reviewers: ${{ github.actor }}
+          body: |-
+            This PR was created in response to a manual trigger of the [draft release workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            Versions have been bumped in [commit ${{ steps.make-commit.outputs.commit }}](${{ steps.make-commit.outputs.commit }}).
+
+            Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.
+
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+
+---
+name: "Release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+  workflow_call:
+
+
+jobs:
+  # Gate
+  validation:
+    name: "Check if repository is not fork AND head is release OR base is bugfix"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'eclipse-edc/MinimumViableDataspace' && (startsWith(github.ref_name, 'bugfix/') || startsWith(github.event.pull_request.head.ref, 'release/')) }}
+    outputs:
+      RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Output release version
+        id: release-version
+        run: |
+          VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+  # Release: GitHub tag & release; Starts a new development cycle if latest release;
+  github-release:
+    name: Publish new github release
+    needs: [ validation ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: needs.validation.outputs.RELEASE_VERSION
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/push-tag
+        with:
+          version: ${{ needs.validation.outputs.RELEASE_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          is_latest: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -22,13 +22,16 @@ name: "Execute E2E Tests"
 on:
   push:
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 5 * * *" # once a day
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+  workflow_run:
+    workflows: [ "Draft Release" ]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,9 +22,14 @@ name: "Verify"
 
 on:
   push:
-  pull_request:
     branches:
       - main
+  pull_request:
+
+  workflow_run:
+    workflows: [ "Draft Release" ]
+    types:
+      - completed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## What this PR changes/adds

this PR adds workflows to create ("draft") a release of MVD. Upon doing so, a Pull-Request is opened.

Merging the PR will then trigger the creation of a GH Release and a Git tag.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
