### PR TITLE
docs: fix typo on gen keys issue #508

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ seed the keys via config or commandline argument. That said, the process is simi
 
 ```shell
 openssl genpkey -algorithm ed25519 -out deployment/assets/consumer_private.pem
-openssl pkey -in assets/consumer_private.pem -pubout -out assets/consumer_public.pem
+openssl pkey -in deployment/assets/consumer_private.pem -pubout -out deployment/assets/consumer_public.pem
 
 # use the same key for provider:
 cp  deployment/assets/consumer_private.pem  deployment/assets/provider_private.pem


### PR DESCRIPTION

What this PR changes/adds

Changes only README to fix typo in command to regenerate keys
Why it does that

As is, command will return :
Can't open assets/issuer_public.pem for writing, No such file or directory
Further notes

N/A
Who will sponsor this feature?

N/A
Linked Issue(s)

fixes #508 