### PR TITLE
fix: use v3 EDR management endpoints in Bruno collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ In the `ControlPlane Management/Get EDR DataAddress for TransferId` request we h
 value from the previous step in the URL path, for example:
 
 ```
-{{HOST}}/api/management/v3/edrs/392d1767-e546-4b54-ab6e-6fb20a3dc12a/dataaddress
+{{HOST}}/api/mgmt/v3/edrs/392d1767-e546-4b54-ab6e-6fb20a3dc12a/dataaddress
 ```
 
 Executing this request produces a response that contains both the endpoint where we can fetch the data, and the

--- a/Requests/ControlPlane Management/Get EDR DataAddress for TransferId.bru
+++ b/Requests/ControlPlane Management/Get EDR DataAddress for TransferId.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{CONSUMER_CP}}/api/mgmt/v4/edrs/{{TRANSFER_PROCESS_ID}}/dataaddress
+  url: {{CONSUMER_CP}}/api/mgmt/v3/edrs/{{TRANSFER_PROCESS_ID}}/dataaddress
   body: none
   auth: inherit
+}
+
+vars:pre-request {
+  TRANSFER_PROCESS_ID: 2595ffc4-b53e-4858-8ba8-52e21c8dde5a
 }
 
 script:pre-request {

--- a/Requests/ControlPlane Management/Get cached EDRs.bru
+++ b/Requests/ControlPlane Management/Get cached EDRs.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{CONSUMER_CP}}/api/mgmt/v4/edrs/request
+  url: {{CONSUMER_CP}}/api/mgmt/v3/edrs/request
   body: json
   auth: inherit
 }


### PR DESCRIPTION
## What this PR changes/adds

This fixes the EDR-related Bruno requests for the MVD `release/0.17.0` flow.

The Bruno collection currently uses the v4 management API for EDR endpoints:

- `/api/mgmt/v4/edrs/request`
- `/api/mgmt/v4/edrs/{transferProcessId}/dataaddress`

However, the EDR DataAddress endpoint is available under the v3 management API:

- `/api/mgmt/v3/edrs/{transferProcessId}/dataaddress`

This PR updates the affected Bruno requests and README documentation accordingly.

## Why it does that

In the current flow, the transfer process can reach `STARTED` successfully and EDR metadata is stored in the consumer controlplane database, but the v4 EDR endpoint returns `404 Not Found`.

Using the v3 EDR endpoint returns the expected DataAddress response.

Verified locally with Podman + KinD:

```bash
curl -i -X GET "http://127.0.0.1/api/mgmt/v3/edrs/<transferProcessId>/dataaddress" \
  -H "Host: cp.consumer.localhost" \
  -H "X-Api-Key: password"
```
Who will sponsor this feature?

N/A - bug fix.

Linked Issue: Closes #604