### PR TITLE
chore: adapt to new lib module structure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,13 +32,10 @@ edc-spi-dcp = { module = "org.eclipse.edc:decentralized-claims-spi", version.ref
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-dataplane-signaling = { module = "org.eclipse.edc:data-plane-signaling-spi", version.ref = "edc" }
 
-# EDC lib dependencies
+# EDC lib dependencies (consolidated, see Connector DR 2026-06-18-lib-module-consolidation)
 edc-lib-jws2020 = { module = "org.eclipse.edc:jws2020-lib", version.ref = "edc" }
-edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
-edc-lib-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
-edc-lib-keys = { module = "org.eclipse.edc:keys-lib", version.ref = "edc" }
-edc-lib-jsonld = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
-edc-lib-token = { module = "org.eclipse.edc:token-lib", version.ref = "edc" }
+edc-lib-jsonld = { module = "org.eclipse.edc:jsonld-lib", version.ref = "edc" }
+edc-lib-core = { module = "org.eclipse.edc:core-lib", version.ref = "edc" }
 
 # EDC Postgres modules
 edc-store-participantcontext-config-sql = { module = "org.eclipse.edc:participantcontext-config-store-sql", version.ref = "edc" }

--- a/launchers/dataplane/build.gradle.kts
+++ b/launchers/dataplane/build.gradle.kts
@@ -25,9 +25,7 @@ dependencies {
     implementation(libs.edc.ext.http)
     implementation(libs.dataplane.sdk)
     implementation(libs.edc.spi.core)
-    implementation(libs.edc.lib.token)
-    implementation(libs.edc.lib.crypto)
-    implementation(libs.edc.lib.keys)
+    implementation(libs.edc.lib.core)
 
     // needed for the key seed extension
     runtimeOnly(libs.tink)

--- a/launchers/identity-hub/build.gradle.kts
+++ b/launchers/identity-hub/build.gradle.kts
@@ -24,8 +24,7 @@ dependencies {
     runtimeOnly(libs.edc.bom.identityhub.sql)
 
     testImplementation(libs.edc.spi.core)
-    testImplementation(libs.edc.lib.crypto)
-    testImplementation(libs.edc.lib.keys)
+    testImplementation(libs.edc.lib.core)
 }
 
 application {

--- a/tests/end2end/build.gradle.kts
+++ b/tests/end2end/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
     // todo: use 2025 once it is used everywhere
-    testImplementation(libs.edc.lib.transform)
     testImplementation(libs.edc.lib.jsonld)
     testImplementation(libs.edc.controlplane.transform)
 }


### PR DESCRIPTION
## What this PR changes/adds

Adapts the MVD to the recent upstream `*-lib` module restructuring

## Why it does that

technical debt

## Further notes

- **Draft**: depends on eclipse-edc/Connector#5844 being merged and published (and on the corresponding IdentityHub
  adoption, eclipse-edc/IdentityHub#1024). The new artifacts are not on a snapshot repository yet. Verified locally
  against a `publishToMavenLocal` build of the consolidation + IdentityHub.

## Who will sponsor this feature?

_TODO: @-mention the sponsoring committer._

## Linked Issue(s)

_n/a_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
